### PR TITLE
Add pip/pipx/pyenv installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ git clone https://github.com/jtsylve/ida-mcp && cd ida-mcp
 uv sync
 ```
 
-Or with pip (requires pip 21.3+ for editable installs with the `uv_build` backend):
+Or with pip (editable installs require pip 21.3+):
 
 ```bash
 git clone https://github.com/jtsylve/ida-mcp && cd ida-mcp
@@ -77,7 +77,7 @@ You can run the server without installing it first:
 # uv
 IDADIR=/path/to/ida uvx ida-mcp
 
-# pipx (IDADIR recommended since pipx uses an isolated environment)
+# pipx (set IDADIR if IDA isn't in a standard location)
 IDADIR=/path/to/ida pipx run ida-mcp
 ```
 
@@ -86,7 +86,7 @@ IDADIR=/path/to/ida pipx run ida-mcp
 $env:IDADIR = "C:\Program Files\IDA Professional 9.3"
 uvx ida-mcp
 
-# pipx (IDADIR recommended since pipx uses an isolated environment)
+# pipx (set IDADIR if IDA isn't in a standard location)
 $env:IDADIR = "C:\Program Files\IDA Professional 9.3"
 pipx run ida-mcp
 ```
@@ -124,13 +124,13 @@ If `ida-mcp` isn't on your `PATH` (e.g. installed into a pyenv or virtualenv), u
 {
   "mcpServers": {
     "ida": {
-      "command": "/home/user/.pyenv/versions/3.12.0/bin/ida-mcp"
+      "command": "/home/user/.pyenv/versions/<version>/bin/ida-mcp"
     }
   }
 }
 ```
 
-On macOS, the path would typically be `/Users/<you>/.pyenv/versions/3.12.0/bin/ida-mcp`.
+On macOS, the path would typically be `/Users/<you>/.pyenv/versions/<version>/bin/ida-mcp`.
 
 If IDA is not in a default location, add `IDADIR` via the `env` key (works with any command):
 
@@ -240,9 +240,9 @@ uv run ruff check src/           # Lint
 uv run ruff format src/          # Format
 uv run ruff check --fix src/     # Lint with auto-fix
 
-# With pip (requires pip 21.3+ for editable installs with uv_build backend)
+# With pip
 pip install -e .                 # Install in editable mode
-pip install pre-commit pytest ruff  # Install dev tools (matches [dependency-groups] dev)
+pip install pre-commit pytest ruff  # Install dev tools (see [dependency-groups] in pyproject.toml)
 ruff check src/                  # Lint
 ruff format src/                 # Format
 ruff check --fix src/            # Lint with auto-fix


### PR DESCRIPTION
## Summary
- Add pip, pipx, and pyenv alternatives alongside uv commands throughout the README
- Add MCP client config examples for non-uv users, including full-path example for pyenv/virtualenv setups
- Clarify that this is a standalone idalib server, not an IDA plugin
- Fix tools summary accuracy (separate demangling/register tracking, add missing data definition and directory tree entries)

Closes #5

## Test plan
- [x] Verified `pip install ida-mcp` works in a clean venv (installs from PyPI wheel, creates `ida-mcp` entry point)
- [x] Verified `uv_build` backend is on PyPI and pip bootstraps it automatically for editable installs
- [ ] Spot-check MCP client config JSON examples render correctly on GitHub