### PR TITLE
Support fastmcp 3.2.0 and use native title= parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "fastmcp>=3.1,<3.2",
+    "fastmcp>=3.1,<3.3",
     "mcp>=1.26,<1.27",
 ]
 

--- a/src/ida_mcp/server.py
+++ b/src/ida_mcp/server.py
@@ -81,25 +81,13 @@ def _auto_title(name: str) -> str:
     return " ".join(w.upper() if w in _UPPERCASE_WORDS else w.title() for w in words)
 
 
-def _inject_title(kwargs: dict[str, Any], name: str | None, fn: Callable[..., Any] | None) -> None:
-    """Add a ``title`` to annotations if not already present.
-
-    Always copies the annotations dict to avoid mutating shared presets
-    like ``ANNO_READ_ONLY``.
-    """
+def _ensure_title(kwargs: dict[str, Any], name: str | None, fn: Callable[..., Any] | None) -> None:
+    """Set ``title`` in *kwargs* if not already present."""
+    if "title" in kwargs and kwargs["title"] is not None:
+        return
     tool_name = name or (fn.__name__ if fn else None)
-    if not tool_name:
-        return
-    annotations = kwargs.get("annotations")
-    if annotations is None:
-        annotations = {}
-    elif isinstance(annotations, dict):
-        annotations = {**annotations}  # avoid mutating shared ANNO_* presets
-    else:
-        return
-    if "title" not in annotations:
-        annotations["title"] = _auto_title(tool_name)
-    kwargs["annotations"] = annotations
+    if tool_name:
+        kwargs["title"] = _auto_title(tool_name)
 
 
 class IDAServer(FastMCP):
@@ -120,7 +108,7 @@ class IDAServer(FastMCP):
     ) -> Callable[[Callable[..., Any]], FunctionTool] | FunctionTool:
         if callable(name_or_fn):
             # @mcp.tool  (no parentheses)
-            _inject_title(kwargs, None, name_or_fn)
+            _ensure_title(kwargs, None, name_or_fn)
             return super().tool(_wrap_sync(name_or_fn), **kwargs)
 
         # @mcp.tool()  or  @mcp.tool("name")  — returns a decorator.
@@ -128,10 +116,10 @@ class IDAServer(FastMCP):
         # defer until the decorated function is known.
         has_name = isinstance(name_or_fn, str)
         if has_name:
-            _inject_title(kwargs, name_or_fn, None)
+            _ensure_title(kwargs, name_or_fn, None)
             dec = super().tool(name_or_fn, **kwargs)
         else:
-            # Copy kwargs so the closure owns its own dict — _inject_title
+            # Copy kwargs so the closure owns its own dict — _ensure_title
             # mutates it when the decorated function is finally known.
             kwargs = {**kwargs}
             dec = None
@@ -139,7 +127,7 @@ class IDAServer(FastMCP):
         def wrapping_decorator(fn: Callable[..., Any]) -> FunctionTool:
             d = dec
             if d is None:
-                _inject_title(kwargs, None, fn)
+                _ensure_title(kwargs, None, fn)
                 d = super(IDAServer, self).tool(None, **kwargs)
             return d(_wrap_sync(fn))
 

--- a/src/ida_mcp/supervisor.py
+++ b/src/ida_mcp/supervisor.py
@@ -36,14 +36,12 @@ import anyio
 import mcp.types as types
 from fastmcp import Client, FastMCP
 from fastmcp.client import StdioTransport
-
-# FastMCP internal imports — not part of the public API as of v3.1.
 from fastmcp.exceptions import ToolError
+from fastmcp.resources import Resource as FastMCPResource
 from fastmcp.resources import ResourceContent, ResourceResult
-from fastmcp.resources.resource import Resource as FastMCPResource
 from fastmcp.resources.template import ResourceTemplate as FastMCPResourceTemplate
-from fastmcp.tools.tool import Tool as FastMCPTool
-from fastmcp.tools.tool import ToolResult
+from fastmcp.tools import Tool as FastMCPTool
+from fastmcp.tools import ToolResult
 from mcp.shared.exceptions import McpError
 
 from ida_mcp.exceptions import (
@@ -366,6 +364,7 @@ class ProxyMCP(FastMCP):
         self._worker_tool_schemas = [
             FastMCPTool(
                 name=t.name,
+                title=t.title,
                 description=t.description,
                 parameters=t.inputSchema,
                 annotations=t.annotations,

--- a/tests/test_server_pure.py
+++ b/tests/test_server_pure.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""Unit tests for server.py pure functions (_auto_title, _inject_title)
+"""Unit tests for server.py pure functions (_auto_title, _ensure_title)
 and Pydantic output-schema validation against representative tool outputs.
 
 These tests run without idalib — IDA modules are stubbed out.
@@ -65,7 +65,7 @@ import pytest  # noqa: E402
 from pydantic import ValidationError  # noqa: E402
 
 from ida_mcp.models import RenameResult  # noqa: E402
-from ida_mcp.server import _auto_title, _inject_title  # noqa: E402
+from ida_mcp.server import _auto_title, _ensure_title  # noqa: E402
 from ida_mcp.tools.functions import (  # noqa: E402
     DecompilationResult,
     DisassemblyResult,
@@ -112,52 +112,44 @@ def test_auto_title_double_underscore():
 
 
 # ---------------------------------------------------------------------------
-# _inject_title
+# _ensure_title
 # ---------------------------------------------------------------------------
 
 
-def test_inject_title_adds_title():
+def test_ensure_title_adds_title():
     kwargs: dict = {"annotations": {"readOnlyHint": True}}
-    _inject_title(kwargs, "get_function", None)
-    assert kwargs["annotations"]["title"] == "Get Function"
+    _ensure_title(kwargs, "get_function", None)
+    assert kwargs["title"] == "Get Function"
 
 
-def test_inject_title_does_not_overwrite():
-    kwargs: dict = {"annotations": {"title": "Custom Title"}}
-    _inject_title(kwargs, "get_function", None)
-    assert kwargs["annotations"]["title"] == "Custom Title"
+def test_ensure_title_does_not_overwrite():
+    kwargs: dict = {"title": "Custom Title"}
+    _ensure_title(kwargs, "get_function", None)
+    assert kwargs["title"] == "Custom Title"
 
 
-def test_inject_title_creates_annotations_if_missing():
+def test_ensure_title_creates_if_missing():
     kwargs: dict = {}
-    _inject_title(kwargs, "get_function", None)
-    assert kwargs["annotations"]["title"] == "Get Function"
+    _ensure_title(kwargs, "get_function", None)
+    assert kwargs["title"] == "Get Function"
 
 
-def test_inject_title_does_not_mutate_original():
-    original = {"readOnlyHint": True}
-    kwargs: dict = {"annotations": original}
-    _inject_title(kwargs, "get_function", None)
-    # The original dict should not have been modified.
-    assert "title" not in original
-
-
-def test_inject_title_from_fn():
+def test_ensure_title_from_fn():
     def my_tool():
         pass
 
     kwargs: dict = {}
-    _inject_title(kwargs, None, my_tool)
-    assert kwargs["annotations"]["title"] == "My Tool"
+    _ensure_title(kwargs, None, my_tool)
+    assert kwargs["title"] == "My Tool"
 
 
-def test_inject_title_name_takes_precedence_over_fn():
+def test_ensure_title_name_takes_precedence_over_fn():
     def fallback():
         pass
 
     kwargs: dict = {}
-    _inject_title(kwargs, "get_xrefs_to", fallback)
-    assert kwargs["annotations"]["title"] == "Get Xrefs To"
+    _ensure_title(kwargs, "get_xrefs_to", fallback)
+    assert kwargs["title"] == "Get Xrefs To"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.1.1"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -348,9 +348,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/83/c95d3bf717698a693eccb43e137a32939d2549876e884e246028bff6ecce/fastmcp-3.1.1.tar.gz", hash = "sha256:db184b5391a31199323766a3abf3a8bfbb8010479f77eca84c0e554f18655c48", size = 17347644, upload-time = "2026-03-14T19:12:20.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/32/4f1b2cfd7b50db89114949f90158b1dcc2c92a1917b9f57c0ff24e47a2f4/fastmcp-3.2.0.tar.gz", hash = "sha256:d4830b8ffc3592d3d9c76dc0f398904cf41f04910e41a0de38cc1004e0903bef", size = 26318581, upload-time = "2026-03-30T20:25:37.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ea/570122de7e24f72138d006f799768e14cc1ccf7fcb22b7750b2bd276c711/fastmcp-3.1.1-py3-none-any.whl", hash = "sha256:8132ba069d89f14566b3266919d6d72e2ec23dd45d8944622dca407e9beda7eb", size = 633754, upload-time = "2026-03-14T19:12:22.736Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/67/684fa2d2de1e7504549d4ca457b4f854ccec3cd3be03bd86b33b599fbf58/fastmcp-3.2.0-py3-none-any.whl", hash = "sha256:e71aba3df16f86f546a4a9e513261d3233bcc92bef0dfa647bac3fa33623f681", size = 705550, upload-time = "2026-03-30T20:25:35.499Z" },
 ]
 
 [[package]]
@@ -426,7 +426,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=3.1,<3.2" },
+    { name = "fastmcp", specifier = ">=3.1,<3.3" },
     { name = "mcp", specifier = ">=1.26,<1.27" },
 ]
 


### PR DESCRIPTION
## Summary
- Widen fastmcp constraint from `>=3.1,<3.2` to `>=3.1,<3.3` to allow fastmcp 3.2.0 (all APIs we use exist since 3.1.0; the wider bound picks up 3.2.0 security hardening, StdioTransport subprocess recovery fix, and bug fixes)
- Migrate off deprecated shim imports (`fastmcp.tools.tool` → `fastmcp.tools`, `fastmcp.resources.resource` → `fastmcp.resources`) — the old paths still work via backward-compat shims in 3.2.0 but are marked for removal
- Replace `_inject_title()` (which hacked title into the `annotations` dict) with `_ensure_title()` using the native `title=` kwarg on `@mcp.tool()` — simpler, no dict copying/mutation needed
- Pass through worker tool titles in supervisor's `_bootstrap_worker_schemas`

## Test plan
- [x] All 70 tests pass
- [x] ruff check + format clean
- [x] Pre-commit hooks pass
- [ ] Manual testing with IDA Pro to verify tool titles propagate correctly