### PR TITLE
Add raw binary support and RestrictedPython sandbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ See `docs/architecture.md` for full details. Key points for editing:
 - **Supervisor** (`supervisor.py`): entry point, `ProxyMCP(FastMCP)` + `WorkerPoolProvider`. Registers management tools directly; worker tools/resources go through the provider chain. Management tools use `_session_id()` (via `try_get_context()` from `context.py`) — no `ctx` parameter in tool schemas.
 - **Worker provider** (`worker_provider.py`): `WorkerPoolProvider(Provider)`, `RoutingTool(Tool)`, `RoutingTemplate(ResourceTemplate)`, `Worker` dataclass. Session-scoped ownership under `_lock` — `close_for_session()` and `detach_all()` are atomic. `ensure_session_cleanup()` registers a disconnect callback on the MCP session's exit stack.
 - **Worker** (`server.py`): `IDAServer(FastMCP)`, one per database, stdio transport. `ida-mcp-worker` entry point.
-- **idalib-safe modules** (importable without `bootstrap()`): `context.py`, `exceptions.py`, `models.py`, `transforms.py`, `prompts/`. The supervisor imports `context.py`, `exceptions.py` (via `worker_provider.py`), `transforms.py`, `prompts/`, and `worker_provider.py`.
+- **idalib-safe modules** (importable without `bootstrap()`): `context.py`, `exceptions.py`, `models.py`, `sandbox.py`, `transforms.py`, `prompts/`. The supervisor imports `context.py`, `exceptions.py`, `transforms.py` (which pulls in `sandbox.py`), `prompts/`, and `worker_provider.py`.
 - **idalib-required modules**: `helpers.py`, `session.py`, `tools/`, `resources.py`. Top-level `ida_*` imports — only loaded in worker processes.
 - `@session.require_open` (no parens) — decorator on nearly every tool
 - All tools return Pydantic models on success; raise `IDAError` on failure

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Raw binaries must be in a writable directory since IDA creates a `.i64` database
 
 ### Multi-database mode
 
-Multiple databases can be open at the same time. By default, `open_database` keeps previously opened databases open. Pass `keep_open=False` to save and close databases owned by the current session before opening the new one. All tools except management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`) require the `database` parameter (the stem ID returned by `open_database` or `list_databases`).
+Multiple databases can be open at the same time. By default, `open_database` keeps previously opened databases open. Pass `keep_open=False` to save and close databases owned by the current session before opening the new one. All tools except management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`, `list_targets`) require the `database` parameter (the stem ID returned by `open_database` or `list_databases`).
 
 ```
 open_database("first.bin")                              # spawns worker (returns immediately)
@@ -186,7 +186,7 @@ To keep token usage manageable, only a set of common analysis tools are directly
 - **`execute`** — sandboxed Python that chains multiple `await call_tool` invocations in a single round trip (supports `asyncio.gather` for parallel queries, loops, and result processing)
 - **`batch`** — sequential multi-tool execution with per-item error collection and progress reporting (up to 50 operations per call)
 
-Tools not in the pinned set are hidden from the listing but remain callable by name. Management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`) are always visible.
+Tools not in the pinned set are hidden from the listing but remain callable by name. Management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`, `list_targets`) are always visible.
 
 The full tool catalog covers all major areas of IDA Pro's functionality:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ The IDA MCP Server is a headless IDA Pro server that communicates over the Model
 ```
 LLM Client  <──stdio──>  ProxyMCP (supervisor.py)
                               │
-                              ├── management tools (open/close/save/list_databases)
+                              ├── management tools (open/close/save/list/wait/list_targets)
                               ├── ida://databases resource
                               ├── prompts/
                               │
@@ -86,7 +86,7 @@ Key behaviors:
 
 The supervisor uses FastMCP's native Provider system to expose worker tools and resources through the standard provider chain, rather than overriding `list_tools()`, `call_tool()`, etc.
 
-**`ProxyMCP`** (`supervisor.py`) subclasses `FastMCP`. It creates a `WorkerPoolProvider` and calls `self.add_provider(worker_pool)`. Management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`) and the `ida://databases` resource are registered directly on the `FastMCP` server via its internal `_local_provider`. Prompts are also registered directly (they don't require database state). An `IDAToolTransform` (a `CatalogTransform` subclass defined in `transforms.py`) is applied at the server level. It pins a set of common analysis tools (e.g. `list_functions`, `decompile_function`, `get_strings`) alongside three meta-tools: `search_tools` (regex discovery of all other tools), `execute` (sandboxed Python that chains `await call_tool` invocations for multi-step pipelines and parallel queries), and `batch` (sequential multi-tool execution with per-item error collection). Tools not in the pinned set are hidden from the tool listing but remain callable by name. Management tools delegate to `WorkerPoolProvider` methods for worker lifecycle and are session-aware: `close_database` delegates to `close_for_session()` which atomically detaches and conditionally terminates under `_lock`; `save_database` checks attachment before proceeding. A `_session_id()` helper uses `try_get_context()` (from `context.py`) to extract the session ID without exposing a `ctx` parameter in the tool schema.
+**`ProxyMCP`** (`supervisor.py`) subclasses `FastMCP`. It creates a `WorkerPoolProvider` and calls `self.add_provider(worker_pool)`. Management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`, `list_targets`) and the `ida://databases` resource are registered directly on the `FastMCP` server via its internal `_local_provider`. Prompts are also registered directly (they don't require database state). An `IDAToolTransform` (a `CatalogTransform` subclass defined in `transforms.py`) is applied at the server level. It pins a set of common analysis tools (e.g. `list_functions`, `decompile_function`, `get_strings`) alongside three meta-tools: `search_tools` (regex discovery of all other tools), `execute` (sandboxed Python that chains `await call_tool` invocations for multi-step pipelines and parallel queries), and `batch` (sequential multi-tool execution with per-item error collection). Tools not in the pinned set are hidden from the tool listing but remain callable by name. Management tools delegate to `WorkerPoolProvider` methods for worker lifecycle and are session-aware: `close_database` delegates to `close_for_session()` which atomically detaches and conditionally terminates under `_lock`; `save_database` checks attachment before proceeding. A `_session_id()` helper uses `try_get_context()` (from `context.py`) to extract the session ID without exposing a `ctx` parameter in the tool schema.
 
 **`WorkerPoolProvider`** (`worker_provider.py`) implements FastMCP's `Provider` interface. It manages worker subprocesses (each via a `fastmcp.Client` with `StdioTransport`) and exposes their tools and resources through the provider chain:
 
@@ -101,7 +101,7 @@ The supervisor uses FastMCP's native Provider system to expose worker tools and 
 
 Tool/resource schemas are bootstrapped lazily from a temporary worker on first access. `RoutingTool` and `RoutingTemplate` both set `task_config = TaskConfig(mode="optional")`.
 
-All tools except management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`) require the `database` parameter (the stem ID returned by `open_database`).
+All tools except management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`, `list_targets`) require the `database` parameter (the stem ID returned by `open_database`).
 
 #### Background analysis
 
@@ -186,9 +186,10 @@ The default limit is 100 for most tools. Some tools use smaller defaults: 50 for
 | `server.py` | Worker entry point (`ida-mcp-worker`) — creates `IDAServer` (a `FastMCP` subclass), auto-discovers and registers all tool modules from `tools/`, runs stdio transport |
 | `session.py` | Database session singleton (per worker), `require_open` decorator |
 | `context.py` | `try_get_context()` — idalib-safe FastMCP context accessor, used by both supervisor and workers |
-| `exceptions.py` | `IDAError(ToolError)` — structured error type |
+| `exceptions.py` | `IDAError(ToolError)` — structured error type, plus idalib-safe validation utilities (`build_ida_args`, `check_processor_ambiguity`, `AMBIGUOUS_PROCESSORS`, `PRIMARY_IDB_EXTENSIONS`) |
 | `helpers.py` | Address parsing, formatting, pagination, resolution helpers, string decoding, MCP annotation presets, meta presets, `Annotated` parameter type aliases, `call_ida` main-thread dispatch, `@ida_dispatch` marker |
 | `models.py` | Shared Pydantic models used across multiple tool modules (e.g. `PaginatedResult`, `FunctionSummary`, `RenameResult`); tool-specific models live in their respective tool modules. FastMCP derives and emits the JSON schema from return type annotations in tool definitions |
+| `sandbox.py` | `RestrictedPythonSandbox` — AST-restricted Python execution for the `execute` meta-tool |
 | `transforms.py` | `IDAToolTransform(CatalogTransform)` — pins common tools, adds `search_tools`, `execute`, and `batch` meta-tools, hides the rest from listing while keeping them callable by name |
 | `resources.py` | MCP resources — read-only, cacheable context endpoints (static binary data + aggregate statistics) |
 | `prompts/` | MCP prompt templates for guided analysis workflows (analysis, security, workflow) |
@@ -216,7 +217,7 @@ def register(mcp: FastMCP):
 
 Key conventions:
 - All `ida_*` imports are top-level (safe because `server.py` calls `bootstrap()` before importing tool modules). Tool modules are auto-discovered via `pkgutil.iter_modules` — any `tools/*.py` with a `register(mcp)` function is loaded automatically
-- `@session.require_open` is applied to all worker tools that need a database (everything except `convert_number`). Management tools (`open_database`, `close_database`, etc.) live on the supervisor, not in worker tool modules
+- `@session.require_open` is applied to all worker tools that need a database (everything except `convert_number`). Management tools (`open_database`, `close_database`, `list_targets`, etc.) live on the supervisor, not in worker tool modules
 - Every tool has MCP annotations (`ANNO_READ_ONLY`, `ANNO_MUTATE`, `ANNO_MUTATE_NON_IDEMPOTENT`, or `ANNO_DESTRUCTIVE`) and `tags=` for categorical grouping. Tools may also have `meta=` presets (`META_DECOMPILER`, `META_BATCH`, `META_READS_FILES`, `META_WRITES_FILES`) for static metadata
 - Use `Annotated` type aliases (`Address`, `Offset`, `Limit`, `FilterPattern`, `OperandIndex`, `HexBytes`) for parameter types — they embed descriptions and validation constraints (e.g. `ge=0`, `ge=1`) directly into the JSON schema
 - Tool docstrings are sent to the LLM as tool descriptions — they should be clear and concise
@@ -260,7 +261,7 @@ The tool modules are organized by IDA domain. Some modules contain both read and
 - `xref_manip.py` — cross-reference manipulation
 - `entry_manip.py` — entry point addition, renaming, and forwarders
 - `makedata.py` — data type definition
-- `load_data.py` — loading bytes into database
+- `load_data.py` — loading bytes and additional binary files into database
 - `func_flags.py` — function flag and hidden range management
 - `regvars.py` — register variable add/delete/rename/comment
 - `srclang.py` — source declaration parsing (C, C++, Objective-C, Swift, Go) via compiler parsers

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -20,7 +20,7 @@ Tools not in the pinned set are hidden from the listing but remain callable by n
 
 **Pagination** — tools that return lists accept `offset` (default 0) and `limit` (default 100; some tools default to 50 or 20) parameters, and return `items`, `total`, `offset`, `limit`, and `has_more` fields.
 
-**Multi-database** — all tools except management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`) require the `database` parameter (the stem ID returned by `open_database` or `list_databases`).
+**Multi-database** — all tools except management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`, `list_targets`) require the `database` parameter (the stem ID returned by `open_database` or `list_databases`).
 
 **Errors** — tools raise `IDAError` (a `ToolError` subclass) on failure. FastMCP catches this and returns `isError=True` with a JSON text body containing `error`, `error_type`, and optional detail fields (e.g. `available_variables`, `valid_types`).
 
@@ -48,6 +48,7 @@ Core database lifecycle management.
 | `get_elf_debug_file_directory` | Get the ELF debug file directory path. |
 | `reload_file` | Reload byte values from the input file. |
 | `wait_for_analysis` | Wait for one or more databases to finish opening and/or auto-analysis. Blocks until the database is ready for tool calls. Call this after `open_database`. Pass `databases` (a list) to wait for several at once — returns as soon as at least one is ready. |
+| `list_targets` | List available processor modules and loaders from the IDA Pro installation. Returns names that can be passed as the `processor` or `loader` parameter to `open_database`. |
 
 ## Functions
 
@@ -464,6 +465,7 @@ Load additional data into the database.
 
 | Tool | Description |
 |------|-------------|
+| `load_additional_binary` | Load an additional binary file into the database at a given address, creating a new segment. Equivalent to IDA's "File > Load file > Additional binary file". |
 | `load_bytes_from_file` | Load bytes from an external file into the database at a target address. |
 | `load_bytes_from_memory` | Load hex-encoded bytes directly into the database at a target address. |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ida-mcp"
-version = "2.2.0.dev1"
+version = "2.2.0.dev2"
 description = "Headless IDA Pro MCP server using idalib"
 readme = "README.md"
 license = "MIT"
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "fastmcp[code-mode]>=3.1,<3.3",
     "mcp>=1.26,<2",
+    "restrictedpython>=8.1,<9",
 ]
 
 [project.urls]

--- a/src/ida_mcp/__init__.py
+++ b/src/ida_mcp/__init__.py
@@ -56,14 +56,14 @@ def _find_idapro_wheel() -> str | None:
          (or ``%APPDATA%/Hex-Rays/IDA Pro/ida-config.json`` on Windows)
       3. Platform-specific default installation paths
     """
-    ida_dir = _find_ida_dir()
+    ida_dir = find_ida_dir()
     if ida_dir is None:
         return None
     matches = glob.glob(os.path.join(ida_dir, "idalib", "python", "idapro-*.whl"))
     return matches[0] if matches else None
 
 
-def _find_ida_dir() -> str | None:
+def find_ida_dir() -> str | None:
     # 1. Environment variable
     env = os.environ.get("IDADIR")
     if env and os.path.isdir(env):

--- a/src/ida_mcp/exceptions.py
+++ b/src/ida_mcp/exceptions.py
@@ -2,15 +2,17 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""IDA MCP error types.
+"""IDA MCP error types and idalib-safe validation.
 
 Separated from ``helpers`` so that modules which cannot load idalib (e.g.
-the supervisor process) can still raise structured errors.
+the supervisor process) can still raise structured errors and validate
+parameters before spawning worker processes.
 """
 
 from __future__ import annotations
 
 import json
+import os
 
 # ToolError is not re-exported from the top-level fastmcp package as of v3.1;
 # if FastMCP reorganizes its internals this import path may need updating.
@@ -40,3 +42,94 @@ class IDAError(ToolError):
         if self.details:
             d.update(self.details)
         return json.dumps(d, separators=(",", ":"))
+
+
+# ---------------------------------------------------------------------------
+# Primary IDA database extensions
+# ---------------------------------------------------------------------------
+
+PRIMARY_IDB_EXTENSIONS: frozenset[str] = frozenset((".i64", ".idb"))
+
+
+# ---------------------------------------------------------------------------
+# Processor ambiguity detection
+# ---------------------------------------------------------------------------
+
+
+def _bitness_ambiguity_hint(name: str, description: str) -> str:
+    """Build a standard hint for processors with ambiguous bitness on raw binaries."""
+    return (
+        f'"{name}" {description} that cannot be auto-detected for raw binaries.  '
+        "In IDA's GUI a dialog prompts for the mode; headless mode picks a "
+        "default that may be wrong.  Use list_targets and pass a specific "
+        "variant via the processor parameter (processor:variant) or set "
+        "bitness after opening."
+    )
+
+
+_X86_VARIANTS = (
+    "  metapc:8086     — 16-bit real mode\n"
+    "  metapc:80386p   — 32-bit protected mode\n"
+    "  metapc:80386r   — 32-bit real mode\n"
+    "  metapc:80486p   — 32-bit protected (486+)"
+)
+
+
+AMBIGUOUS_PROCESSORS: dict[str, str] = {
+    "arm": (
+        '"arm" is ambiguous for raw binaries — it defaults to AArch64 '
+        "(64-bit) in headless mode.  Use a specific variant:\n"
+        "  arm:ARMv7-M    — Cortex-M (32-bit Thumb-2)\n"
+        "  arm:ARMv7-A    — 32-bit A-profile\n"
+        "  arm:ARMv7-R    — 32-bit R-profile\n"
+        "  arm:ARMv8-M    — ARMv8-M (32-bit)\n"
+        "  arm:ARMv8-A    — ARMv8 A-profile (32-bit)\n"
+        "  arm:ARMv9-A    — ARMv9 A-profile (32-bit)\n"
+        'For 64-bit ARM, use "aarch64" as the processor.'
+    ),
+    "metapc": (
+        '"metapc" supports 16-bit, 32-bit, and 64-bit x86 modes.  '
+        "For raw binaries IDA cannot auto-detect the mode.  "
+        f"Use a variant to select:\n{_X86_VARIANTS}\n"
+        'For 64-bit x86, the default may work or try "metapc:Pentium 4".'
+    ),
+    "pc": (
+        '"pc" supports 16-bit, 32-bit, and 64-bit x86 modes.  '
+        "For raw binaries IDA cannot auto-detect the mode.  "
+        f"Use a variant to select:\n{_X86_VARIANTS}\n"
+        'The canonical processor name is "metapc", not "pc".'
+    ),
+    "mips": _bitness_ambiguity_hint("mips", "has 32-bit and 64-bit modes"),
+    "mipsl": _bitness_ambiguity_hint("mipsl", "(MIPS little-endian) has 32-bit and 64-bit modes"),
+    "ppc": _bitness_ambiguity_hint("ppc", "has 32-bit and 64-bit modes"),
+    "riscv": _bitness_ambiguity_hint("riscv", "has 32-bit (RV32) and 64-bit (RV64) modes"),
+}
+
+
+def check_processor_ambiguity(processor: str, file_path: str, force_new: bool) -> None:
+    """Raise :class:`IDAError` if *processor* is ambiguous for a raw binary.
+
+    Processors like ``arm`` and ``metapc`` support multiple bitness modes.
+    For structured formats (ELF, PE, ...) IDA reads the bitness from file
+    headers, but for raw binaries it shows an interactive dialog — which
+    is suppressed in headless mode, silently picking a (often wrong) default.
+    """
+    if not processor or ":" in processor:
+        return  # Auto-detect or variant already specified.
+
+    # Opening an existing IDA database — bitness is stored in the DB.
+    _, ext = os.path.splitext(file_path)
+    if ext.lower() in PRIMARY_IDB_EXTENSIONS:
+        return
+
+    # If not forcing a fresh analysis, an existing database sidecar means
+    # IDA will reuse stored analysis (including bitness).
+    if not force_new:
+        resolved = os.path.abspath(os.path.expanduser(file_path))
+        for db_ext in PRIMARY_IDB_EXTENSIONS:
+            if os.path.isfile(resolved + db_ext):
+                return
+
+    hint = AMBIGUOUS_PROCESSORS.get(processor.lower())
+    if hint:
+        raise IDAError(hint, error_type="AmbiguousProcessor")

--- a/src/ida_mcp/exceptions.py
+++ b/src/ida_mcp/exceptions.py
@@ -133,3 +133,64 @@ def check_processor_ambiguity(processor: str, file_path: str, force_new: bool) -
     hint = AMBIGUOUS_PROCESSORS.get(processor.lower())
     if hint:
         raise IDAError(hint, error_type="AmbiguousProcessor")
+
+
+# ---------------------------------------------------------------------------
+# IDA command-line args builder (idalib-safe)
+# ---------------------------------------------------------------------------
+
+
+def build_ida_args(
+    *,
+    processor: str = "",
+    loader: str = "",
+    base_address: str = "",
+    options: str = "",
+) -> str | None:
+    """Build an IDA command-line args string from structured parameters.
+
+    Returns ``None`` when no arguments are needed.  Raises :class:`IDAError`
+    on invalid *base_address* or when *options* duplicates a flag that is
+    already provided by a structured parameter.
+    """
+    # Reject options that duplicate a structured parameter already in use.
+    if options:
+        for flag, value, param_name in (
+            ("-p", processor, "processor"),
+            ("-T", loader, "loader"),
+            ("-b", base_address, "base_address"),
+        ):
+            if value and flag in options:
+                raise IDAError(
+                    f"options contains '{flag}' — use the {param_name} parameter instead "
+                    f"of passing '{flag}' in options to avoid duplicate flags.",
+                    error_type="InvalidArgument",
+                )
+
+    args_parts: list[str] = []
+    if processor:
+        args_parts.append(f"-p{processor}")
+    if loader:
+        # Values containing spaces must be quoted so IDA's C-level arg parser
+        # doesn't split them into separate positional arguments.
+        val = f'"{loader}"' if " " in loader else loader
+        args_parts.append(f"-T{val}")
+    if base_address:
+        try:
+            addr = int(base_address, 0)
+        except ValueError:
+            raise IDAError(
+                f"Invalid base_address: {base_address!r}. "
+                "Provide a hex (0x...) or decimal integer.",
+                error_type="InvalidArgument",
+            ) from None
+        if addr & 0xF:
+            raise IDAError(
+                f"base_address {base_address} is not 16-byte aligned. "
+                "IDA requires paragraph alignment (multiple of 0x10).",
+                error_type="InvalidArgument",
+            )
+        args_parts.append(f"-b{addr >> 4:#x}")
+    if options:
+        args_parts.append(options)
+    return " ".join(args_parts) or None

--- a/src/ida_mcp/exceptions.py
+++ b/src/ida_mcp/exceptions.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 
 # ToolError is not re-exported from the top-level fastmcp package as of v3.1;
 # if FastMCP reorganizes its internals this import path may need updating.
@@ -154,13 +155,15 @@ def build_ida_args(
     already provided by a structured parameter.
     """
     # Reject options that duplicate a structured parameter already in use.
+    # Match flags only at the start of the string or after whitespace to
+    # avoid false positives on longer flags (e.g. "-p" inside "--prefer").
     if options:
         for flag, value, param_name in (
             ("-p", processor, "processor"),
             ("-T", loader, "loader"),
             ("-b", base_address, "base_address"),
         ):
-            if value and flag in options:
+            if value and re.search(rf"(?:^|\s){re.escape(flag)}", options):
                 raise IDAError(
                     f"options contains '{flag}' — use the {param_name} parameter instead "
                     f"of passing '{flag}' in options to avoid duplicate flags.",

--- a/src/ida_mcp/sandbox.py
+++ b/src/ida_mcp/sandbox.py
@@ -119,6 +119,15 @@ def _inplacevar(op: str, x: Any, y: Any) -> Any:
     return fn(x, y)
 
 
+def _safe_hasattr(obj: Any, name: str) -> bool:
+    """``hasattr`` that respects RestrictedPython's attribute guards."""
+    try:
+        safer_getattr(obj, name)
+        return True
+    except AttributeError:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Builtins available inside the sandbox
 # ---------------------------------------------------------------------------
@@ -149,11 +158,12 @@ _SANDBOX_BUILTINS: dict[str, Any] = {
     "max": max,
     # Numeric
     "bin": bin,
-    # Introspection
+    # Introspection — getattr/hasattr must go through safer_getattr to block
+    # dunder access; raw builtins would bypass the _getattr_ AST guard.
     "type": type,
     "isinstance": isinstance,
-    "hasattr": hasattr,
-    "getattr": getattr,
+    "hasattr": _safe_hasattr,
+    "getattr": safer_getattr,
     # Formatting
     "format": format,
     "print": print,
@@ -174,6 +184,10 @@ def _make_globals(
         "_getitem_": operator.getitem,
         "_iter_unpack_sequence_": guarded_unpack_sequence,
         "_unpack_sequence_": guarded_unpack_sequence,
+        # _write_ wraps attribute/item stores.  The permissive lambda is the
+        # standard RestrictedPython pattern — dunder writes are already blocked
+        # at compile time by the AST transformer, so a runtime guard adds no
+        # security benefit and would break attribute assignment on user classes.
         "_write_": lambda obj: obj,
         "_inplacevar_": _inplacevar,
     }

--- a/src/ida_mcp/sandbox.py
+++ b/src/ida_mcp/sandbox.py
@@ -87,7 +87,7 @@ def _safe_import(
     fromlist: tuple[str, ...] = (),
     level: int = 0,
 ) -> Any:
-    if name not in _ALLOWED_IMPORTS:
+    if name.split(".", maxsplit=1)[0] not in _ALLOWED_IMPORTS:
         raise ImportError(f'Import of "{name}" is not allowed in the sandbox')
     return __import__(name, globals, locals, fromlist, level)
 
@@ -158,6 +158,8 @@ _SANDBOX_BUILTINS: dict[str, Any] = {
     "max": max,
     # Numeric
     "bin": bin,
+    "hex": hex,
+    "oct": oct,
     # Introspection — getattr/hasattr must go through safer_getattr to block
     # dunder access; raw builtins would bypass the _getattr_ AST guard.
     "type": type,
@@ -222,13 +224,30 @@ class RestrictedPythonSandbox:
         inputs: dict[str, Any] | None = None,
         external_functions: dict[str, Callable[..., Any]] | None = None,
     ) -> Any:
-        # Wrap top-level code in an async function so await is valid syntax.
-        lines = code.strip().splitlines()
-        indented = "\n".join("    " + line for line in lines)
-        wrapped = f"async def {_WRAPPER_NAME}():\n{indented}\n"
+        # Wrap top-level code in an async function at the AST level so
+        # await is valid syntax without text-based re-indentation (which
+        # would corrupt multi-line string literals).
+        tree = ast.parse(code, filename="<execute>", mode="exec")
+        wrapper = ast.AsyncFunctionDef(
+            name=_WRAPPER_NAME,
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[],
+            ),
+            body=tree.body or [ast.Pass()],
+            decorator_list=[],
+            returns=None,
+        )
+        tree.body = [wrapper]
+        ast.fix_missing_locations(tree)
 
         bytecode = compile_restricted(
-            wrapped,
+            tree,
             filename="<execute>",
             mode="exec",
             policy=_AsyncRestrictingNodeTransformer,

--- a/src/ida_mcp/sandbox.py
+++ b/src/ida_mcp/sandbox.py
@@ -190,6 +190,9 @@ def _make_globals(
         # standard RestrictedPython pattern — dunder writes are already blocked
         # at compile time by the AST transformer, so a runtime guard adds no
         # security benefit and would break attribute assignment on user classes.
+        # Safety: sandbox code can only mutate objects it can reach.  call_tool
+        # returns JSON-deserialized dicts (copies), not live internal state, so
+        # mutation cannot affect server internals.
         "_write_": lambda obj: obj,
         "_inplacevar_": _inplacevar,
     }

--- a/src/ida_mcp/sandbox.py
+++ b/src/ida_mcp/sandbox.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: © 2026 Joe T. Sylve, Ph.D. <joe.sylve@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""Sandboxed Python execution using RestrictedPython.
+
+Implements the ``SandboxProvider`` protocol from
+``fastmcp.experimental.transforms.code_mode`` using RestrictedPython for
+AST-level code restriction with a custom policy that allows async/await.
+"""
+
+from __future__ import annotations
+
+import ast
+import operator
+from collections.abc import Callable
+from typing import Any
+
+from RestrictedPython import compile_restricted, safe_builtins
+from RestrictedPython.Guards import guarded_unpack_sequence, safer_getattr
+from RestrictedPython.transformer import RestrictingNodeTransformer
+
+# ---------------------------------------------------------------------------
+# Custom policy — allow async/await on top of standard restrictions
+# ---------------------------------------------------------------------------
+
+_WRAPPER_NAME = "sandboxmain"
+
+
+class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
+    """Extends RestrictedPython's default policy to permit async constructs.
+
+    ``async def``, ``await``, ``async for``, and ``async with`` are blocked
+    by the upstream transformer.  This subclass mirrors the handling of their
+    synchronous equivalents so that ``await call_tool(...)`` and
+    ``asyncio.gather(...)`` work inside execute blocks.
+    """
+
+    def visit_AsyncFunctionDef(self, node):
+        self.check_name(node, node.name, allow_magic_methods=True)
+        self.check_function_argument_names(node)
+        with self.print_info.new_print_scope():
+            node = self.node_contents_visit(node)
+            self.inject_print_collector(node)
+        return node
+
+    def visit_Await(self, node):
+        return self.node_contents_visit(node)
+
+    def visit_AsyncFor(self, node):
+        return self.guard_iter(node)
+
+    def visit_AsyncWith(self, node):
+        node = self.node_contents_visit(node)
+        for item in reversed(node.items):
+            if isinstance(item.optional_vars, ast.Tuple):
+                tmp_target, unpack = self.gen_unpack_wrapper(node, item.optional_vars)
+                item.optional_vars = tmp_target
+                node.body.insert(0, unpack)
+        return node
+
+
+# ---------------------------------------------------------------------------
+# Import whitelist
+# ---------------------------------------------------------------------------
+
+_ALLOWED_IMPORTS = frozenset(
+    {
+        "asyncio",
+        "collections",
+        "functools",
+        "itertools",
+        "json",
+        "math",
+        "operator",
+        "re",
+        "struct",
+        "typing",
+    }
+)
+
+
+def _safe_import(
+    name: str,
+    globals: dict | None = None,
+    locals: dict | None = None,
+    fromlist: tuple[str, ...] = (),
+    level: int = 0,
+) -> Any:
+    if name not in _ALLOWED_IMPORTS:
+        raise ImportError(f'Import of "{name}" is not allowed in the sandbox')
+    return __import__(name, globals, locals, fromlist, level)
+
+
+# ---------------------------------------------------------------------------
+# Guard implementations
+# ---------------------------------------------------------------------------
+
+_INPLACE_OPS: dict[str, Callable[[Any, Any], Any]] = {
+    "+=": operator.iadd,
+    "-=": operator.isub,
+    "*=": operator.imul,
+    "/=": operator.itruediv,
+    "//=": operator.ifloordiv,
+    "%=": operator.imod,
+    "**=": operator.ipow,
+    "&=": operator.iand,
+    "|=": operator.ior,
+    "^=": operator.ixor,
+    ">>=": operator.irshift,
+    "<<=": operator.ilshift,
+}
+
+
+def _inplacevar(op: str, x: Any, y: Any) -> Any:
+    fn = _INPLACE_OPS.get(op)
+    if fn is None:
+        raise ValueError(f"Unsupported in-place operation: {op}")
+    return fn(x, y)
+
+
+# ---------------------------------------------------------------------------
+# Builtins available inside the sandbox
+# ---------------------------------------------------------------------------
+
+_SANDBOX_BUILTINS: dict[str, Any] = {
+    **safe_builtins,
+    "__import__": _safe_import,
+    # Container types (safe_builtins omits these)
+    "list": list,
+    "dict": dict,
+    "set": set,
+    "frozenset": frozenset,
+    "bytearray": bytearray,
+    "memoryview": memoryview,
+    # Iteration helpers
+    "map": map,
+    "filter": filter,
+    "enumerate": enumerate,
+    "reversed": reversed,
+    "iter": iter,
+    "next": next,
+    "zip": zip,
+    # Aggregation
+    "any": any,
+    "all": all,
+    "sum": sum,
+    "min": min,
+    "max": max,
+    # Numeric
+    "bin": bin,
+    # Introspection
+    "type": type,
+    "isinstance": isinstance,
+    "hasattr": hasattr,
+    "getattr": getattr,
+    # Formatting
+    "format": format,
+    "print": print,
+    "super": super,
+}
+
+
+def _make_globals(
+    *,
+    inputs: dict[str, Any] | None = None,
+    external_functions: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the restricted globals dict for ``exec()``."""
+    glb: dict[str, Any] = {
+        "__builtins__": _SANDBOX_BUILTINS,
+        "_getiter_": iter,
+        "_getattr_": safer_getattr,
+        "_getitem_": operator.getitem,
+        "_iter_unpack_sequence_": guarded_unpack_sequence,
+        "_unpack_sequence_": guarded_unpack_sequence,
+        "_write_": lambda obj: obj,
+        "_inplacevar_": _inplacevar,
+    }
+    if inputs:
+        glb.update(inputs)
+    if external_functions:
+        glb.update(external_functions)
+    return glb
+
+
+# ---------------------------------------------------------------------------
+# SandboxProvider implementation
+# ---------------------------------------------------------------------------
+
+
+class RestrictedPythonSandbox:
+    """Sandbox provider backed by RestrictedPython.
+
+    Compiles user code with AST-level restrictions (no ``eval``, ``exec``,
+    ``open``, dangerous attribute access, etc.) while allowing full Python
+    semantics for safe operations — including ``int(s, 16)``, ``import
+    struct``, and ``async``/``await``.
+
+    Implements the ``SandboxProvider`` protocol from
+    ``fastmcp.experimental.transforms.code_mode``.
+    """
+
+    async def run(
+        self,
+        code: str,
+        *,
+        inputs: dict[str, Any] | None = None,
+        external_functions: dict[str, Callable[..., Any]] | None = None,
+    ) -> Any:
+        # Wrap top-level code in an async function so await is valid syntax.
+        lines = code.strip().splitlines()
+        indented = "\n".join("    " + line for line in lines)
+        wrapped = f"async def {_WRAPPER_NAME}():\n{indented}\n"
+
+        bytecode = compile_restricted(
+            wrapped,
+            filename="<execute>",
+            mode="exec",
+            policy=_AsyncRestrictingNodeTransformer,
+        )
+
+        glb = _make_globals(inputs=inputs, external_functions=external_functions)
+        exec(bytecode, glb)
+        return await glb[_WRAPPER_NAME]()

--- a/src/ida_mcp/sandbox.py
+++ b/src/ida_mcp/sandbox.py
@@ -4,9 +4,9 @@
 
 """Sandboxed Python execution using RestrictedPython.
 
-Implements the ``SandboxProvider`` protocol from
-``fastmcp.experimental.transforms.code_mode`` using RestrictedPython for
-AST-level code restriction with a custom policy that allows async/await.
+Uses RestrictedPython for AST-level code restriction with a custom policy
+that allows async/await.  Used by the ``execute`` meta-tool in
+``transforms.py``.
 """
 
 from __future__ import annotations
@@ -204,20 +204,17 @@ def _make_globals(
 
 
 # ---------------------------------------------------------------------------
-# SandboxProvider implementation
+# RestrictedPythonSandbox
 # ---------------------------------------------------------------------------
 
 
 class RestrictedPythonSandbox:
-    """Sandbox provider backed by RestrictedPython.
+    """Sandbox backed by RestrictedPython.
 
     Compiles user code with AST-level restrictions (no ``eval``, ``exec``,
     ``open``, dangerous attribute access, etc.) while allowing full Python
     semantics for safe operations — including ``int(s, 16)``, ``import
     struct``, and ``async``/``await``.
-
-    Implements the ``SandboxProvider`` protocol from
-    ``fastmcp.experimental.transforms.code_mode``.
     """
 
     async def run(

--- a/src/ida_mcp/session.py
+++ b/src/ida_mcp/session.py
@@ -42,7 +42,7 @@ _ERROR_CODES: dict[int, str] = {
 _IDB_EXTENSIONS: tuple[str, ...] = (".i64", ".idb", ".id0", ".id1", ".id2", ".nam", ".til")
 
 # Primary IDA database extensions (the ones that can be opened directly).
-_PRIMARY_IDB_EXTENSIONS: frozenset[str] = frozenset((".i64", ".idb"))
+PRIMARY_IDB_EXTENSIONS: frozenset[str] = frozenset((".i64", ".idb"))
 
 
 class Session:
@@ -64,6 +64,7 @@ class Session:
         file_path: str,
         run_auto_analysis: bool = False,
         force_new: bool = False,
+        options: str | None = None,
     ) -> dict:
         """Open a binary for analysis. Auto-closes any previously open database.
 
@@ -76,6 +77,10 @@ class Session:
         When *force_new* is ``True``, any existing IDA database files
         alongside the binary (``.i64``, ``.idb``, etc.) are deleted before
         opening, forcing a fresh analysis from the raw binary.
+
+        *options* is an optional string of additional IDA command-line
+        arguments (e.g. ``-parm`` to select the ARM processor module,
+        ``-TGeneric`` for a specific loader).
         """
         path = os.path.abspath(os.path.expanduser(file_path))
 
@@ -83,7 +88,7 @@ class Session:
         # (which is what idalib expects) and allow opening even when only the
         # database exists.
         _, ext = os.path.splitext(path)
-        if ext.lower() in _PRIMARY_IDB_EXTENSIONS:
+        if ext.lower() in PRIMARY_IDB_EXTENSIONS:
             binary_path = os.path.splitext(path)[0]
             if not os.path.isfile(path):
                 raise IDAError(f"Database not found: {path}", error_type="FileNotFoundError")
@@ -107,8 +112,13 @@ class Session:
                     log.info("force_new: removing %s", db_file)
                     os.remove(db_file)
 
-        log.debug("Calling idapro.open_database(%s, run_auto_analysis=%s)", path, run_auto_analysis)
-        result = idapro.open_database(path, run_auto_analysis)
+        log.debug(
+            "Calling idapro.open_database(%s, run_auto_analysis=%s, args=%r)",
+            path,
+            run_auto_analysis,
+            options,
+        )
+        result = idapro.open_database(path, run_auto_analysis, args=options)
         if result != 0:
             message = _ERROR_CODES.get(result, f"Unknown error (code {result})")
             log.error("idapro.open_database returned error code %d: %s", result, message)

--- a/src/ida_mcp/session.py
+++ b/src/ida_mcp/session.py
@@ -23,6 +23,7 @@ import ida_idp
 import ida_kernwin
 import idapro
 
+from ida_mcp.exceptions import PRIMARY_IDB_EXTENSIONS
 from ida_mcp.helpers import Cancelled, IDAError
 
 log = logging.getLogger(__name__)
@@ -40,9 +41,6 @@ _ERROR_CODES: dict[int, str] = {
 
 # File extensions created by IDA alongside the input binary.
 _IDB_EXTENSIONS: tuple[str, ...] = (".i64", ".idb", ".id0", ".id1", ".id2", ".nam", ".til")
-
-# Primary IDA database extensions (the ones that can be opened directly).
-PRIMARY_IDB_EXTENSIONS: frozenset[str] = frozenset((".i64", ".idb"))
 
 
 class Session:

--- a/src/ida_mcp/supervisor.py
+++ b/src/ida_mcp/supervisor.py
@@ -9,8 +9,9 @@ and resource reads to the appropriate worker via the ``WorkerPoolProvider``.
 Prompts are registered directly on the supervisor.
 
 All tools except management tools (``open_database``, ``close_database``,
-``save_database``, ``list_databases``, ``wait_for_analysis``) require the
-``database`` parameter (the stem ID returned by ``open_database``).
+``save_database``, ``list_databases``, ``wait_for_analysis``,
+``list_targets``) require the ``database`` parameter (the stem ID
+returned by ``open_database``).
 
 The supervisor never imports ``idapro`` or any ``ida_*`` module.
 """
@@ -19,11 +20,15 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import platform as plat
 
 import mcp.types as types
 from fastmcp import FastMCP
 
+from ida_mcp import find_ida_dir
 from ida_mcp.context import try_get_context
+from ida_mcp.exceptions import IDAError
 from ida_mcp.prompts import register_all as register_prompts
 from ida_mcp.transforms import IDAToolTransform
 from ida_mcp.worker_provider import (
@@ -33,6 +38,32 @@ from ida_mcp.worker_provider import (
 )
 
 log = logging.getLogger(__name__)
+
+# Shared lib extension for the current platform.
+_DYLIB_EXT = {"Darwin": ".dylib", "Windows": ".dll"}.get(plat.system(), ".so")
+
+
+def _list_module_names(directory: str) -> list[str]:
+    """List IDA plugin module names (stem of .dylib/.so/.dll and .py files)."""
+    if not os.path.isdir(directory):
+        return []
+    names: set[str] = set()
+    for entry in os.listdir(directory):
+        stem, ext = os.path.splitext(entry)
+        if ext in (_DYLIB_EXT, ".py"):
+            names.add(stem)
+    return sorted(names)
+
+
+def _list_targets() -> dict:
+    """Enumerate available processors and loaders from the IDA installation."""
+    ida_dir = find_ida_dir()
+    if ida_dir is None:
+        raise IDAError("IDA Pro installation not found", error_type="NotFound")
+    return {
+        "processors": _list_module_names(os.path.join(ida_dir, "procs")),
+        "loaders": _list_module_names(os.path.join(ida_dir, "loaders")),
+    }
 
 
 def _session_id() -> str | None:
@@ -98,7 +129,7 @@ class ProxyMCP(FastMCP):
             "## Addressing\n"
             "All tools except management tools (open_database, "
             "close_database, list_databases, wait_for_analysis, "
-            "save_database) require the database parameter — the stem ID "
+            "save_database, list_targets) require the database parameter — the stem ID "
             "returned by open_database.\n\n"
             'Addresses accept hex strings ("0x401000"), bare hex '
             '("4010a0"), decimal, or symbol names ("main").\n\n'
@@ -112,17 +143,33 @@ class ProxyMCP(FastMCP):
             "ida://<database>/idb/entrypoints. Each also has a "
             "/search/{pattern} variant for regex filtering.\n\n"
             #
+            # --- Tool selection ---
+            #
+            "## Choosing the right call pattern\n"
+            "ONE target? → Call the tool directly. Never wrap in execute.\n\n"
+            "Multiple independent calls (same or different tools)? → "
+            "Use **batch** (up to 50 operations per request, sequential "
+            "with per-item error collection and progress reporting). "
+            "Prefer batch over execute — it is simpler and more robust.\n\n"
+            "Conditional logic, filtering results, or chaining tool A "
+            "output into tool B? → Use **execute** with "
+            "`await call_tool(name, params)` for Python control flow.\n\n"
+            "Cross-database parallel queries? → Use execute with "
+            "`asyncio.gather` and explicit `database` params. Note: "
+            "calls to the same database are serialized by the worker, "
+            "so asyncio.gather only helps for cross-database work.\n\n"
+            #
             # --- Tool discovery ---
             #
-            "## Tool discovery & execution (code mode)\n"
-            "Analysis tools are accessed through code mode. "
-            "Use search_tools(pattern) to find tools by keyword, then "
-            "execute(code) to chain multiple tool calls in a single "
-            "Python block via `await call_tool(name, params)`. "
-            "Use `return` to produce output. "
+            "## Tool discovery\n"
+            "Common analysis tools are pinned and always visible.  "
+            "Additional tools are discoverable via search_tools(pattern) "
+            "and callable directly by name, or through execute/batch. "
+            "Hidden tools work identically to pinned tools — no special "
+            "syntax required.\n\n"
             "Management tools (open_database, close_database, list_databa"
-            "ses, wait_for_analysis, save_database) are always visible "
-            "and called directly — not through execute.\n\n"
+            "ses, wait_for_analysis, save_database, list_targets) are always visible "
+            "and called directly — not through execute or batch.\n\n"
             #
             # --- Session trust ---
             #
@@ -156,7 +203,15 @@ class ProxyMCP(FastMCP):
             "execute tool description for details.\n"
             "- Pointer tables: use read_pointer_table to read vtables, "
             "dispatch tables, and token dictionaries — auto-dereferences "
-            "pointers and detects strings at targets."
+            "pointers and detects strings at targets.\n"
+            "- Raw binary / firmware: open with processor and loader "
+            "set explicitly.  **ARM gotcha:** the arm module defaults "
+            'to AArch64 for raw binaries — use "arm:ARMv7-M" for '
+            'Cortex-M, not just "arm".  Use list_targets to see '
+            "available processors and loaders. "
+            "After opening, use rebase_program to set the correct base "
+            "address, create_segment for memory-mapped regions (MMIO, "
+            "SRAM), and reanalyze_range after setup changes."
         )
 
     # ------------------------------------------------------------------
@@ -183,6 +238,10 @@ class ProxyMCP(FastMCP):
             keep_open: bool = True,
             database_id: str = "",
             force_new: bool = False,
+            processor: str = "",
+            loader: str = "",
+            base_address: str = "",
+            options: str = "",
         ) -> dict:
             """Open a binary or existing IDA database for analysis.
 
@@ -222,6 +281,41 @@ class ProxyMCP(FastMCP):
             before opening, discarding all prior analysis, renames,
             comments, and type annotations.  Use only when a previous
             database is stale or incompatible (IDA error code 4).
+
+            **Processor and loader selection:** by default IDA auto-detects
+            the processor and file format from the binary's headers.  Use
+            *processor* and *loader* to override when auto-detection picks
+            the wrong option (e.g. a raw firmware blob with no headers).
+
+            Args:
+                file_path: Path to the binary file or IDA database.
+                run_auto_analysis: Wait for IDA auto-analysis after opening.
+                keep_open: Keep previously open databases (default True).
+                database_id: Custom database identifier.
+                force_new: Delete existing database files and start fresh.
+                processor: Optional.  IDA processor module, optionally
+                           with a variant after a colon.  IDA auto-detects
+                           from file headers when omitted, but may guess
+                           wrong for raw binaries.  Use list_targets to see
+                           available module names.  **ARM gotcha:** the
+                           ``arm`` module defaults to AArch64 (64-bit) for
+                           raw binaries — use ``arm:ARMv7-M`` for Cortex-M
+                           firmware, ``arm:ARMv7-A`` for 32-bit A-profile,
+                           or ``arm:ARMv7-R`` for R-profile.  Other
+                           examples: ``metapc`` (x86/x64), ``ppc``,
+                           ``mips``, ``mipsl``.
+                loader: Optional.  IDA loader name (e.g. "ELF", "PE",
+                        "Mach-O", "Binary file").  IDA auto-detects when
+                        omitted.  Use list_targets to see available loaders.
+                base_address: Optional.  Base loading address for the binary
+                              (hex or decimal, e.g. "0x20040000").  Must be
+                              16-byte aligned.  Primarily useful for raw
+                              binary files; structured formats contain their
+                              own base addresses.
+                options: Optional.  Additional IDA command-line arguments.
+                         Processor, loader, and base address flags are added
+                         automatically from the other parameters — do not
+                         duplicate them here.
             """
             ctx = try_get_context()
             sid = ctx.session_id if ctx else None
@@ -237,6 +331,10 @@ class ProxyMCP(FastMCP):
                 session_id=sid,
                 mcp_session=mcp_session,
                 force_new=force_new,
+                processor=processor,
+                loader=loader,
+                base_address=base_address,
+                options=options,
             )
             await _notify_resources_changed()
             return result
@@ -324,6 +422,16 @@ class ProxyMCP(FastMCP):
             if databases:
                 return await pool.wait_for_ready_multi(databases)
             return await pool.wait_for_ready(database)
+
+        @self.tool(annotations={"title": "List Targets"})
+        async def list_targets() -> dict:
+            """List available processor modules and loaders for open_database.
+
+            Returns the names that can be passed as the ``processor`` or
+            ``loader`` parameter to open_database.  These are discovered
+            from the IDA Pro installation directory.
+            """
+            return _list_targets()
 
     # ------------------------------------------------------------------
     # Supervisor-owned resources

--- a/src/ida_mcp/supervisor.py
+++ b/src/ida_mcp/supervisor.py
@@ -28,7 +28,7 @@ from fastmcp import FastMCP
 
 from ida_mcp import find_ida_dir
 from ida_mcp.context import try_get_context
-from ida_mcp.exceptions import IDAError
+from ida_mcp.exceptions import IDAError, check_processor_ambiguity
 from ida_mcp.prompts import register_all as register_prompts
 from ida_mcp.transforms import IDAToolTransform
 from ida_mcp.worker_provider import (
@@ -97,7 +97,8 @@ class ProxyMCP(FastMCP):
     # Instructions
     # ------------------------------------------------------------------
 
-    def _build_instructions(self) -> str:
+    @staticmethod
+    def _build_instructions() -> str:
         return (
             "IDA Pro binary analysis server with multi-database support.\n\n"
             #
@@ -167,8 +168,8 @@ class ProxyMCP(FastMCP):
             "and callable directly by name, or through execute/batch. "
             "Hidden tools work identically to pinned tools — no special "
             "syntax required.\n\n"
-            "Management tools (open_database, close_database, list_databa"
-            "ses, wait_for_analysis, save_database, list_targets) are always visible "
+            "Management tools (open_database, close_database, list_databases, "
+            "wait_for_analysis, save_database, list_targets) are always visible "
             "and called directly — not through execute or batch.\n\n"
             #
             # --- Session trust ---
@@ -317,6 +318,9 @@ class ProxyMCP(FastMCP):
                          automatically from the other parameters — do not
                          duplicate them here.
             """
+            # Fail fast on ambiguous processor before spawning a worker.
+            check_processor_ambiguity(processor, file_path, force_new)
+
             ctx = try_get_context()
             sid = ctx.session_id if ctx else None
             pool.ensure_session_cleanup(ctx)

--- a/src/ida_mcp/tools/database.py
+++ b/src/ida_mcp/tools/database.py
@@ -28,7 +28,7 @@ from ida_mcp.helpers import (
     is_bad_addr,
     resolve_address,
 )
-from ida_mcp.session import session
+from ida_mcp.session import PRIMARY_IDB_EXTENSIONS, session
 
 # ---------------------------------------------------------------------------
 # Models
@@ -147,6 +147,89 @@ _DBFL_MAP = {
 }
 
 
+# Processors with bitness ambiguity for raw binaries.  When a bare processor
+# name is used without a variant (no ":" separator), IDA shows an interactive
+# dialog to choose the mode.  In headless idalib mode the dialog is suppressed
+# and IDA silently picks a default — often the wrong one.
+def _bitness_ambiguity_hint(name: str, description: str) -> str:
+    """Build a standard hint for processors with ambiguous bitness on raw binaries."""
+    return (
+        f'"{name}" {description} that cannot be auto-detected for raw binaries.  '
+        "In IDA's GUI a dialog prompts for the mode; headless mode picks a "
+        "default that may be wrong.  Use list_targets and pass a specific "
+        "variant via the processor parameter (processor:variant) or set "
+        "bitness after opening."
+    )
+
+
+_AMBIGUOUS_PROCESSORS: dict[str, str] = {
+    "arm": (
+        '"arm" is ambiguous for raw binaries — it defaults to AArch64 '
+        "(64-bit) in headless mode.  Use a specific variant:\n"
+        "  arm:ARMv7-M    — Cortex-M (32-bit Thumb-2)\n"
+        "  arm:ARMv7-A    — 32-bit A-profile\n"
+        "  arm:ARMv7-R    — 32-bit R-profile\n"
+        "  arm:ARMv8-M    — ARMv8-M (32-bit)\n"
+        "  arm:ARMv8-A    — ARMv8 A-profile (32-bit)\n"
+        "  arm:ARMv9-A    — ARMv9 A-profile (32-bit)\n"
+        'For 64-bit ARM, use "aarch64" as the processor.'
+    ),
+    "metapc": (
+        '"metapc" supports 16-bit, 32-bit, and 64-bit x86 modes.  '
+        "For raw binaries IDA cannot auto-detect the mode.  "
+        "Use a variant to select:\n"
+        "  metapc:8086     — 16-bit real mode\n"
+        "  metapc:80386p   — 32-bit protected mode\n"
+        "  metapc:80386r   — 32-bit real mode\n"
+        "  metapc:80486p   — 32-bit protected (486+)\n"
+        'For 64-bit x86, the default may work or try "metapc:Pentium 4".'
+    ),
+    "pc": (
+        '"pc" supports 16-bit, 32-bit, and 64-bit x86 modes.  '
+        "For raw binaries IDA cannot auto-detect the mode.  "
+        "Use a variant to select:\n"
+        "  metapc:8086     — 16-bit real mode\n"
+        "  metapc:80386p   — 32-bit protected mode\n"
+        "  metapc:80386r   — 32-bit real mode\n"
+        "  metapc:80486p   — 32-bit protected (486+)\n"
+        'The canonical processor name is "metapc", not "pc".'
+    ),
+    "mips": _bitness_ambiguity_hint("mips", "has 32-bit and 64-bit modes"),
+    "mipsl": _bitness_ambiguity_hint("mipsl", "(MIPS little-endian) has 32-bit and 64-bit modes"),
+    "ppc": _bitness_ambiguity_hint("ppc", "has 32-bit and 64-bit modes"),
+    "riscv": _bitness_ambiguity_hint("riscv", "has 32-bit (RV32) and 64-bit (RV64) modes"),
+}
+
+
+def _check_processor_ambiguity(processor: str, file_path: str, force_new: bool) -> None:
+    """Raise :class:`IDAError` if *processor* is ambiguous for a raw binary.
+
+    Processors like ``arm`` and ``metapc`` support multiple bitness modes.
+    For structured formats (ELF, PE, …) IDA reads the bitness from file
+    headers, but for raw binaries it shows an interactive dialog — which
+    is suppressed in headless mode, silently picking a (often wrong) default.
+    """
+    if not processor or ":" in processor:
+        return  # Auto-detect or variant already specified.
+
+    # Opening an existing IDA database — bitness is stored in the DB.
+    _, ext = os.path.splitext(file_path)
+    if ext.lower() in PRIMARY_IDB_EXTENSIONS:
+        return
+
+    # If not forcing a fresh analysis, an existing database sidecar means
+    # IDA will reuse stored analysis (including bitness).
+    if not force_new:
+        resolved = os.path.abspath(os.path.expanduser(file_path))
+        for db_ext in PRIMARY_IDB_EXTENSIONS:
+            if os.path.isfile(resolved + db_ext):
+                return
+
+    hint = _AMBIGUOUS_PROCESSORS.get(processor.lower())
+    if hint:
+        raise IDAError(hint, error_type="AmbiguousProcessor")
+
+
 def register(mcp: FastMCP):
     @mcp.tool(
         annotations=ANNO_MUTATE,
@@ -156,6 +239,10 @@ def register(mcp: FastMCP):
         file_path: str,
         run_auto_analysis: bool = False,
         force_new: bool = False,
+        processor: str = "",
+        loader: str = "",
+        base_address: str = "",
+        options: str = "",
     ) -> OpenDatabaseResult:
         """Open a binary or existing IDA database for analysis.
 
@@ -177,8 +264,59 @@ def register(mcp: FastMCP):
                        files (.i64, .idb, etc.) and start fresh from the raw
                        binary, discarding all prior analysis.  Useful when IDA
                        returns error code 4 due to a stale or incompatible database.
+            processor: Optional.  IDA processor module, optionally with a
+                       variant after a colon.  IDA auto-detects from file
+                       headers when omitted, but may guess wrong for raw
+                       binaries.  **ARM gotcha:** the ``arm`` module
+                       defaults to AArch64 (64-bit) for raw binaries —
+                       use ``arm:ARMv7-M`` for Cortex-M firmware,
+                       ``arm:ARMv7-A`` for 32-bit A-profile, or
+                       ``arm:ARMv7-R`` for R-profile.  Other examples:
+                       ``metapc`` (x86/x64), ``ppc``, ``mips``, ``mipsl``.
+            loader: Optional.  IDA loader to use instead of auto-detection
+                    (e.g. "ELF", "PE", "Mach-O", "Binary file").
+            base_address: Optional.  Base loading address for the binary
+                          (hex or decimal).  Must be 16-byte aligned.
+                          Primarily useful for raw binary files; structured
+                          formats (ELF, PE, Mach-O) contain their own base
+                          addresses.
+            options: Optional.  Additional IDA command-line arguments.
+                     Processor, loader, and base address flags are added
+                     automatically from the other parameters — do not
+                     duplicate them here.
         """
-        session.open(file_path, run_auto_analysis, force_new=force_new)
+        _check_processor_ambiguity(processor, file_path, force_new)
+
+        # Build the IDA command-line args string from structured params.
+        # Values containing spaces must be quoted so IDA's C-level arg parser
+        # doesn't split them into separate positional arguments.
+        args_parts: list[str] = []
+        if processor:
+            args_parts.append(f"-p{processor}")
+        if loader:
+            val = f'"{loader}"' if " " in loader else loader
+            args_parts.append(f"-T{val}")
+        if base_address:
+            try:
+                addr = int(base_address, 0)
+            except ValueError:
+                raise IDAError(
+                    f"Invalid base_address: {base_address!r}. "
+                    "Provide a hex (0x…) or decimal integer.",
+                    error_type="InvalidArgument",
+                ) from None
+            if addr & 0xF:
+                raise IDAError(
+                    f"base_address {base_address} is not 16-byte aligned. "
+                    "IDA requires paragraph alignment (multiple of 0x10).",
+                    error_type="InvalidArgument",
+                )
+            args_parts.append(f"-b{addr >> 4:#x}")
+        if options:
+            args_parts.append(options)
+        ida_args = " ".join(args_parts) or None
+
+        session.open(file_path, run_auto_analysis, force_new=force_new, options=ida_args)
 
         return OpenDatabaseResult(
             status="ok",

--- a/src/ida_mcp/tools/database.py
+++ b/src/ida_mcp/tools/database.py
@@ -17,7 +17,7 @@ import ida_segment
 from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
-from ida_mcp.exceptions import check_processor_ambiguity
+from ida_mcp.exceptions import build_ida_args, check_processor_ambiguity
 from ida_mcp.helpers import (
     ANNO_DESTRUCTIVE,
     ANNO_MUTATE,
@@ -203,36 +203,14 @@ def register(mcp: FastMCP):
                      automatically from the other parameters — do not
                      duplicate them here.
         """
+        # The supervisor also calls check_processor_ambiguity before spawning
+        # the worker (fail-fast).  We repeat it here so the worker's own
+        # open_database tool is safe when used standalone (e.g. direct worker
+        # connections or tests).
         check_processor_ambiguity(processor, file_path, force_new)
-
-        # Build the IDA command-line args string from structured params.
-        # Values containing spaces must be quoted so IDA's C-level arg parser
-        # doesn't split them into separate positional arguments.
-        args_parts: list[str] = []
-        if processor:
-            args_parts.append(f"-p{processor}")
-        if loader:
-            val = f'"{loader}"' if " " in loader else loader
-            args_parts.append(f"-T{val}")
-        if base_address:
-            try:
-                addr = int(base_address, 0)
-            except ValueError:
-                raise IDAError(
-                    f"Invalid base_address: {base_address!r}. "
-                    "Provide a hex (0x…) or decimal integer.",
-                    error_type="InvalidArgument",
-                ) from None
-            if addr & 0xF:
-                raise IDAError(
-                    f"base_address {base_address} is not 16-byte aligned. "
-                    "IDA requires paragraph alignment (multiple of 0x10).",
-                    error_type="InvalidArgument",
-                )
-            args_parts.append(f"-b{addr >> 4:#x}")
-        if options:
-            args_parts.append(options)
-        ida_args = " ".join(args_parts) or None
+        ida_args = build_ida_args(
+            processor=processor, loader=loader, base_address=base_address, options=options
+        )
 
         session.open(file_path, run_auto_analysis, force_new=force_new, options=ida_args)
 

--- a/src/ida_mcp/tools/database.py
+++ b/src/ida_mcp/tools/database.py
@@ -17,6 +17,7 @@ import ida_segment
 from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
+from ida_mcp.exceptions import check_processor_ambiguity
 from ida_mcp.helpers import (
     ANNO_DESTRUCTIVE,
     ANNO_MUTATE,
@@ -28,7 +29,7 @@ from ida_mcp.helpers import (
     is_bad_addr,
     resolve_address,
 )
-from ida_mcp.session import PRIMARY_IDB_EXTENSIONS, session
+from ida_mcp.session import session
 
 # ---------------------------------------------------------------------------
 # Models
@@ -147,89 +148,6 @@ _DBFL_MAP = {
 }
 
 
-# Processors with bitness ambiguity for raw binaries.  When a bare processor
-# name is used without a variant (no ":" separator), IDA shows an interactive
-# dialog to choose the mode.  In headless idalib mode the dialog is suppressed
-# and IDA silently picks a default — often the wrong one.
-def _bitness_ambiguity_hint(name: str, description: str) -> str:
-    """Build a standard hint for processors with ambiguous bitness on raw binaries."""
-    return (
-        f'"{name}" {description} that cannot be auto-detected for raw binaries.  '
-        "In IDA's GUI a dialog prompts for the mode; headless mode picks a "
-        "default that may be wrong.  Use list_targets and pass a specific "
-        "variant via the processor parameter (processor:variant) or set "
-        "bitness after opening."
-    )
-
-
-_AMBIGUOUS_PROCESSORS: dict[str, str] = {
-    "arm": (
-        '"arm" is ambiguous for raw binaries — it defaults to AArch64 '
-        "(64-bit) in headless mode.  Use a specific variant:\n"
-        "  arm:ARMv7-M    — Cortex-M (32-bit Thumb-2)\n"
-        "  arm:ARMv7-A    — 32-bit A-profile\n"
-        "  arm:ARMv7-R    — 32-bit R-profile\n"
-        "  arm:ARMv8-M    — ARMv8-M (32-bit)\n"
-        "  arm:ARMv8-A    — ARMv8 A-profile (32-bit)\n"
-        "  arm:ARMv9-A    — ARMv9 A-profile (32-bit)\n"
-        'For 64-bit ARM, use "aarch64" as the processor.'
-    ),
-    "metapc": (
-        '"metapc" supports 16-bit, 32-bit, and 64-bit x86 modes.  '
-        "For raw binaries IDA cannot auto-detect the mode.  "
-        "Use a variant to select:\n"
-        "  metapc:8086     — 16-bit real mode\n"
-        "  metapc:80386p   — 32-bit protected mode\n"
-        "  metapc:80386r   — 32-bit real mode\n"
-        "  metapc:80486p   — 32-bit protected (486+)\n"
-        'For 64-bit x86, the default may work or try "metapc:Pentium 4".'
-    ),
-    "pc": (
-        '"pc" supports 16-bit, 32-bit, and 64-bit x86 modes.  '
-        "For raw binaries IDA cannot auto-detect the mode.  "
-        "Use a variant to select:\n"
-        "  metapc:8086     — 16-bit real mode\n"
-        "  metapc:80386p   — 32-bit protected mode\n"
-        "  metapc:80386r   — 32-bit real mode\n"
-        "  metapc:80486p   — 32-bit protected (486+)\n"
-        'The canonical processor name is "metapc", not "pc".'
-    ),
-    "mips": _bitness_ambiguity_hint("mips", "has 32-bit and 64-bit modes"),
-    "mipsl": _bitness_ambiguity_hint("mipsl", "(MIPS little-endian) has 32-bit and 64-bit modes"),
-    "ppc": _bitness_ambiguity_hint("ppc", "has 32-bit and 64-bit modes"),
-    "riscv": _bitness_ambiguity_hint("riscv", "has 32-bit (RV32) and 64-bit (RV64) modes"),
-}
-
-
-def _check_processor_ambiguity(processor: str, file_path: str, force_new: bool) -> None:
-    """Raise :class:`IDAError` if *processor* is ambiguous for a raw binary.
-
-    Processors like ``arm`` and ``metapc`` support multiple bitness modes.
-    For structured formats (ELF, PE, …) IDA reads the bitness from file
-    headers, but for raw binaries it shows an interactive dialog — which
-    is suppressed in headless mode, silently picking a (often wrong) default.
-    """
-    if not processor or ":" in processor:
-        return  # Auto-detect or variant already specified.
-
-    # Opening an existing IDA database — bitness is stored in the DB.
-    _, ext = os.path.splitext(file_path)
-    if ext.lower() in PRIMARY_IDB_EXTENSIONS:
-        return
-
-    # If not forcing a fresh analysis, an existing database sidecar means
-    # IDA will reuse stored analysis (including bitness).
-    if not force_new:
-        resolved = os.path.abspath(os.path.expanduser(file_path))
-        for db_ext in PRIMARY_IDB_EXTENSIONS:
-            if os.path.isfile(resolved + db_ext):
-                return
-
-    hint = _AMBIGUOUS_PROCESSORS.get(processor.lower())
-    if hint:
-        raise IDAError(hint, error_type="AmbiguousProcessor")
-
-
 def register(mcp: FastMCP):
     @mcp.tool(
         annotations=ANNO_MUTATE,
@@ -285,7 +203,7 @@ def register(mcp: FastMCP):
                      automatically from the other parameters — do not
                      duplicate them here.
         """
-        _check_processor_ambiguity(processor, file_path, force_new)
+        check_processor_ambiguity(processor, file_path, force_new)
 
         # Build the IDA command-line args string from structured params.
         # Values containing spaces must be quoted so IDA's C-level arg parser

--- a/src/ida_mcp/tools/functions.py
+++ b/src/ida_mcp/tools/functions.py
@@ -144,17 +144,14 @@ def _passes_type_filter(func, filter_type: str) -> bool:
     """Check if a function passes the type filter."""
     if not filter_type:
         return True
-    is_thunk = bool(func.flags & ida_funcs.FUNC_THUNK)
-    is_lib = bool(func.flags & ida_funcs.FUNC_LIB)
-    is_noret = bool(func.flags & ida_funcs.FUNC_NORET)
     if filter_type == "thunk":
-        return is_thunk
+        return bool(func.flags & ida_funcs.FUNC_THUNK)
     if filter_type == "library":
-        return is_lib
+        return bool(func.flags & ida_funcs.FUNC_LIB)
     if filter_type == "noreturn":
-        return is_noret
+        return bool(func.flags & ida_funcs.FUNC_NORET)
     if filter_type == "user":
-        return not (is_thunk or is_lib)
+        return not (func.flags & (ida_funcs.FUNC_THUNK | ida_funcs.FUNC_LIB))
     return False
 
 
@@ -165,6 +162,7 @@ def _batch_functions(filters: list[FunctionFilter]) -> BatchFunctionsResult:
     qty = ida_funcs.get_func_qty()
     cancelled = False
     remaining = len(compiled)
+    total = 0
     for i in range(qty):
         if is_cancelled():
             cancelled = True
@@ -172,6 +170,7 @@ def _batch_functions(filters: list[FunctionFilter]) -> BatchFunctionsResult:
         func = ida_funcs.getn_func(i)
         if func is None:
             continue
+        total += 1
         name: str | None = None
         for fi, (pat, ft, lim, _) in enumerate(compiled):
             if len(per_filter[fi]) >= lim:
@@ -200,7 +199,7 @@ def _batch_functions(filters: list[FunctionFilter]) -> BatchFunctionsResult:
             pattern=raw_pattern,
             filter_type=ft,
             matches=per_filter[fi],
-            total_scanned=qty,
+            total_scanned=total,
         )
         for fi, (_, ft, _, raw_pattern) in enumerate(compiled)
     ]

--- a/src/ida_mcp/tools/load_data.py
+++ b/src/ida_mcp/tools/load_data.py
@@ -26,6 +26,15 @@ from ida_mcp.helpers import (
 from ida_mcp.session import session
 
 
+class LoadAdditionalBinaryResult(BaseModel):
+    """Result of loading an additional binary file."""
+
+    file: str = Field(description="Source file path.")
+    load_address: str = Field(description="Load address (hex).")
+    file_offset: int = Field(description="File offset.")
+    size: int = Field(description="Number of bytes loaded (0 = entire file).")
+
+
 class LoadBytesFromFileResult(BaseModel):
     """Result of loading bytes from a file."""
 
@@ -44,7 +53,78 @@ class LoadBytesFromMemoryResult(BaseModel):
     old_bytes: str = Field(description="Previous bytes at target (hex).")
 
 
+def _validate_and_open(file_path: str, file_offset: int) -> tuple[str, int, object]:
+    """Validate a file path and offset, then open it as an IDA linput.
+
+    Returns ``(resolved_path, file_size, linput)``.  The caller **must**
+    close the linput via ``ida_diskio.close_linput(li)`` when done.
+    """
+    path = os.path.expanduser(file_path)
+    if not os.path.isfile(path):
+        raise IDAError(f"File not found: {path}", error_type="FileNotFoundError")
+
+    file_size = os.path.getsize(path)
+    if file_offset >= file_size:
+        raise IDAError("File offset beyond file size", error_type="InvalidArgument")
+
+    li = ida_diskio.open_linput(path, False)
+    if li is None:
+        raise IDAError(f"Failed to open file: {path}", error_type="OpenFailed")
+
+    return path, file_size, li
+
+
 def register(mcp: FastMCP):
+    @mcp.tool(
+        annotations=ANNO_DESTRUCTIVE,
+        tags={"modification", "loading"},
+        meta=META_READS_FILES,
+    )
+    @session.require_open
+    def load_additional_binary(
+        file_path: str,
+        load_address: Address,
+        file_offset: int = 0,
+        size: int = 0,
+    ) -> LoadAdditionalBinaryResult:
+        """Load an additional binary file into the database at a given address.
+
+        Creates a new segment and loads the file contents into it.  This is
+        equivalent to IDA's "File > Load file > Additional binary file"
+        and is useful for loading firmware components, overlays, or
+        supplementary data files into an existing database.
+
+        Unlike load_bytes_from_file (which overwrites bytes in an existing
+        segment), this creates the segment automatically.
+
+        Args:
+            file_path: Absolute path to the binary file to load.
+            load_address: Address where the file should be loaded (hex or
+                          decimal).  A new segment will be created here.
+            file_offset: Offset within the file to start reading from.
+            size: Number of bytes to load (0 = rest of file from offset).
+        """
+        ea = resolve_address(load_address)
+        path, _, li = _validate_and_open(file_path, file_offset)
+
+        basepara = ea >> 4
+        binoff = ea & 0xF
+
+        try:
+            result = ida_loader.load_binary_file(path, li, 0, file_offset, basepara, binoff, size)
+        finally:
+            ida_diskio.close_linput(li)
+
+        if not result:
+            raise IDAError("Failed to load binary file into database", error_type="LoadFailed")
+
+        return LoadAdditionalBinaryResult(
+            file=path,
+            load_address=format_address(ea),
+            file_offset=file_offset,
+            size=size,
+        )
+
     @mcp.tool(
         annotations=ANNO_DESTRUCTIVE,
         tags={"modification", "patching"},
@@ -70,27 +150,16 @@ def register(mcp: FastMCP):
             size: Number of bytes to load (0 = rest of file from offset).
         """
         ea = resolve_address(target_address)
-
-        path = os.path.expanduser(file_path)
-        if not os.path.isfile(path):
-            raise IDAError(f"File not found: {path}", error_type="FileNotFoundError")
-
-        file_size = os.path.getsize(path)
-        if file_offset >= file_size:
-            raise IDAError("File offset beyond file size", error_type="InvalidArgument")
-
-        if size == 0:
-            size = file_size - file_offset
-
-        li = ida_diskio.open_linput(path, False)
-        if li is None:
-            raise IDAError(f"Failed to open file: {path}", error_type="OpenFailed")
-
-        # Read old bytes before overwriting (cap preview at 256 bytes)
-        preview_size = min(size, 256)
-        old_bytes_data = ida_bytes.get_bytes(ea, preview_size)
+        path, file_size, li = _validate_and_open(file_path, file_offset)
 
         try:
+            if size == 0:
+                size = file_size - file_offset
+
+            # Read old bytes before overwriting (cap preview at 256 bytes)
+            preview_size = min(size, 256)
+            old_bytes_data = ida_bytes.get_bytes(ea, preview_size)
+
             result = ida_loader.file2base(li, file_offset, ea, ea + size, 1)
         finally:
             ida_diskio.close_linput(li)

--- a/src/ida_mcp/tools/load_data.py
+++ b/src/ida_mcp/tools/load_data.py
@@ -101,6 +101,9 @@ def register(mcp: FastMCP):
             file_path: Absolute path to the binary file to load.
             load_address: Address where the file should be loaded (hex or
                           decimal).  A new segment will be created here.
+                          Should be 16-byte (paragraph) aligned for clean
+                          segment boundaries; non-aligned addresses are
+                          accepted but may produce unexpected segment starts.
             file_offset: Offset within the file to start reading from.
             size: Number of bytes to load (0 = rest of file from offset).
         """

--- a/src/ida_mcp/tools/search.py
+++ b/src/ida_mcp/tools/search.py
@@ -187,12 +187,14 @@ def _batch_strings(filters: list[StringFilter]) -> BatchStringsResult:
     si = ida_strlist.string_info_t()
     cancelled = False
     remaining = len(compiled)
+    total = 0
     for i in range(qty):
         if is_cancelled():
             cancelled = True
             break
         if not ida_strlist.get_strlist_item(si, i):
             continue
+        total += 1
         value: str | None = None
         for fi, (pat, ml, lim, _) in enumerate(compiled):
             if len(per_filter[fi]) >= lim:
@@ -219,7 +221,7 @@ def _batch_strings(filters: list[StringFilter]) -> BatchStringsResult:
             break
 
     groups = [
-        StringGroup(pattern=raw_pattern, matches=per_filter[fi], total_scanned=qty)
+        StringGroup(pattern=raw_pattern, matches=per_filter[fi], total_scanned=total)
         for fi, (_, _, _, raw_pattern) in enumerate(compiled)
     ]
     return BatchStringsResult(groups=groups, cancelled=cancelled)

--- a/src/ida_mcp/tools/srclang.py
+++ b/src/ida_mcp/tools/srclang.py
@@ -49,7 +49,7 @@ def register(mcp: FastMCP):
         """Get the name of the currently selected source language parser.
 
         Returns the name of the parser (e.g. "clang") used for parsing
-        C/C++ type declarations. Returns empty string if no parser is active.
+        type declarations. Returns empty string if no parser is active.
         """
         name = ida_srclang.get_selected_parser_name()
         return GetSourceParserResult(parser=name or "")
@@ -65,7 +65,7 @@ def register(mcp: FastMCP):
         is_path: bool = False,
         parser_name: str = "",
     ) -> ParseSourceResult:
-        """Parse C/C++ source declarations and import types into the database.
+        """Parse source declarations and import types into the database.
 
         Uses an installed compiler parser (e.g. Clang) to parse type
         declarations from inline source code or a file. Successfully parsed
@@ -73,7 +73,7 @@ def register(mcp: FastMCP):
         for type application.
 
         Args:
-            source: C/C++ source code string, or a file path if is_path=true.
+            source: Source code string, or a file path if is_path=true.
             language: Source language — "c", "cpp"/"c++", "objc", "swift", "go".
                       Ignored if parser_name is specified.
             is_path: If true, source is interpreted as a file path.

--- a/src/ida_mcp/transforms.py
+++ b/src/ida_mcp/transforms.py
@@ -18,7 +18,6 @@ import re
 from collections.abc import Sequence
 from typing import Annotated, Any
 
-from fastmcp.experimental.transforms.code_mode import MontySandboxProvider
 from fastmcp.server.context import Context
 from fastmcp.server.transforms import GetToolNext
 from fastmcp.server.transforms.catalog import CatalogTransform
@@ -26,14 +25,14 @@ from fastmcp.tools.base import ToolResult
 from fastmcp.tools.tool import Tool
 from fastmcp.utilities.versions import VersionSpec
 from pydantic import BaseModel, Field
-from pydantic_monty import MontyRuntimeError
 
 from ida_mcp.exceptions import IDAError
+from ida_mcp.sandbox import RestrictedPythonSandbox
 
 # Management tools are registered directly on the supervisor and must remain
 # visible in the tool listing — they handle database lifecycle, not analysis.
 # worker_provider.py derives _MANAGEMENT_TOOLS from this set (minus
-# list_databases, which is supervisor-only, not proxied to workers).
+# list_databases and list_targets, which are supervisor-only).
 MANAGEMENT_TOOLS = frozenset(
     {
         "open_database",
@@ -41,15 +40,17 @@ MANAGEMENT_TOOLS = frozenset(
         "list_databases",
         "wait_for_analysis",
         "save_database",
+        "list_targets",
     }
 )
 
 META_TOOLS = frozenset({"search_tools", "execute", "batch"})
 
-# Tools that are always directly visible alongside the meta-tools.
+# Tools that are always directly visible.
 PINNED_TOOLS = frozenset(
     {
         *MANAGEMENT_TOOLS,
+        *META_TOOLS,
         "get_database_info",
         # Exploration
         "list_functions",
@@ -144,24 +145,27 @@ return {"decomp": decomp, "xrefs": xrefs}
 Need ONE tool with no post-processing?
   → Call the tool directly. Never wrap it in execute.
 
-Need the SAME tool on multiple targets?
+Multiple independent calls (same or different tools)?
   → Check if the tool has a **batch parameter** first (e.g. get_strings
     has `filters=[...]` for multi-pattern single-pass search).
   → Otherwise, use the **batch** meta-tool for sequential multi-tool
     execution with per-item error collection and progress reporting.
-  → Only fall back to execute loops if you need inter-step processing logic.
+  → Only fall back to execute if you need conditional logic or filtering.
 
-Need to chain: tool A's output feeds tool B's input?
+Conditional logic, filtering, or chaining tool A output into B?
   → Use execute. This is what it's for.
 
-Need multiple INDEPENDENT queries in parallel?
-  → Use execute with asyncio.gather.
+Cross-database parallel queries?
+  → Use execute with asyncio.gather and explicit `database` params.
+  Note: calls to the same database are serialized by the worker —
+  asyncio.gather only helps for cross-database work.
 
 **Important:**
 - Only IDA analysis tools are callable via `call_tool` inside execute. \
 Management tools (open_database, close_database, list_databases, \
-wait_for_analysis, save_database) and meta-tools (search_tools, execute, \
-batch) must be called directly — they are not available inside execute.
+wait_for_analysis, save_database, list_targets) and meta-tools \
+(search_tools, execute, batch) must be called directly — they are \
+not available inside execute.
 - `database` is auto-injected into every `call_tool` invocation. \
 To target a different database for one call, pass `database` \
 explicitly in that call's params.
@@ -172,14 +176,16 @@ like "0x9AFC". To convert in execute: `int(addr, 16)` or \
 `int(addr, 0)`. Both work.
 - `filter_pattern` parameters are **Python regex** — escape special \
 characters (use `re.escape("C++")`, not `"C++"` literally).
-- `asyncio`, `json`, `re`, and `math` are importable. \
+- `asyncio`, `collections`, `functools`, `itertools`, `json`, \
+`math`, `operator`, `re`, `struct`, and `typing` are importable. \
 No filesystem or network I/O.
 
 ## Execute patterns
 
 - **Chain outputs:** decompile a function, extract callees, resolve them:
   ```
-  import re, asyncio
+  import re
+  import asyncio
   decomp = await call_tool("decompile_function", {"address": "main"})
   addrs = re.findall(r'sub_([0-9A-Fa-f]+)', decomp["pseudocode"])
   xrefs = await asyncio.gather(*[
@@ -412,7 +418,7 @@ class IDAToolTransform(CatalogTransform):
         return self._cached_execute_tool
 
     def _make_execute_tool(self) -> Tool:
-        sandbox = MontySandboxProvider()
+        sandbox = RestrictedPythonSandbox()
 
         async def execute(
             code: Annotated[
@@ -462,10 +468,12 @@ class IDAToolTransform(CatalogTransform):
                     inputs={"database": database},
                     external_functions={"call_tool": call_tool},
                 )
-            except MontyRuntimeError as exc:
-                # Re-raise as IDAError so MCP clients see isError=True.
-                inner = exc.exception()
-                raise IDAError(str(inner) if inner is not None else str(exc)) from exc
+            except SyntaxError as exc:
+                raise IDAError(str(exc), error_type="SyntaxError") from exc
+            except IDAError:
+                raise
+            except Exception as exc:
+                raise IDAError(str(exc)) from exc
 
             if call_count == 1 and not _has_processing_logic(code):
                 hint = (

--- a/src/ida_mcp/transforms.py
+++ b/src/ida_mcp/transforms.py
@@ -266,7 +266,7 @@ set_decompiler_comment(address, comment)
 - `ida://<database>/idb/imports` — full import table
 - `ida://<database>/idb/exports` — full export table
 - `ida://<database>/idb/entrypoints` — entry points
-- `ida://<database>/statistics` — function/segment/string counts
+- `ida://<database>/idb/statistics` — function/segment/string counts
 Each also has a `/search/{pattern}` variant for regex filtering.\
 """
 

--- a/src/ida_mcp/worker_provider.py
+++ b/src/ida_mcp/worker_provider.py
@@ -80,8 +80,8 @@ _WORKER_META_KEYS = (
 # Worker tools that the supervisor exposes as its own management tools.
 # Excluded from RoutingTool wrapping during bootstrap to avoid duplicates.
 # Derived from MANAGEMENT_TOOLS (transforms.py) minus list_databases
-# (supervisor-only, not proxied to workers).
-_MANAGEMENT_TOOLS = MANAGEMENT_TOOLS - {"list_databases"}
+# and list_targets (supervisor-only, not proxied to workers).
+_MANAGEMENT_TOOLS = MANAGEMENT_TOOLS - {"list_databases", "list_targets"}
 
 _RFC6570_QUERY_RE = re.compile(r"\{\?([^}]+)\}")
 
@@ -1011,6 +1011,10 @@ class WorkerPoolProvider(Provider):
         session_id: str | None = None,
         mcp_session: ServerSession | None = None,
         force_new: bool = False,
+        processor: str = "",
+        loader: str = "",
+        base_address: str = "",
+        options: str = "",
     ) -> dict[str, Any]:
         """Spawn a worker subprocess and open a database in it."""
         # Resolve the real path but keep the original extension so the worker
@@ -1108,6 +1112,10 @@ class WorkerPoolProvider(Provider):
                 force_new=force_new,
                 stale_worker=stale_worker,
                 mcp_session=mcp_session,
+                processor=processor,
+                loader=loader,
+                base_address=base_address,
+                options=options,
             ),
             name=f"background-spawn-{db_id}",
         )
@@ -1130,6 +1138,10 @@ class WorkerPoolProvider(Provider):
         force_new: bool,
         stale_worker: Worker | None,
         mcp_session: ServerSession | None,
+        processor: str = "",
+        loader: str = "",
+        base_address: str = "",
+        options: str = "",
     ) -> None:
         """Spawn a worker subprocess and open the database in the background.
 
@@ -1177,10 +1189,20 @@ class WorkerPoolProvider(Provider):
             log.debug(
                 "Worker subprocess connected for %s, sending open_database(%s)", db_id, file_path
             )
-            result = await client.call_tool_mcp(
-                "open_database",
-                {"file_path": file_path, "run_auto_analysis": False, "force_new": force_new},
-            )
+            open_args: dict[str, Any] = {
+                "file_path": file_path,
+                "run_auto_analysis": False,
+                "force_new": force_new,
+            }
+            if processor:
+                open_args["processor"] = processor
+            if loader:
+                open_args["loader"] = loader
+            if base_address:
+                open_args["base_address"] = base_address
+            if options:
+                open_args["options"] = options
+            result = await client.call_tool_mcp("open_database", open_args)
 
             result_data = parse_result(result)
             log.debug("Worker open_database result for %s: %s", db_id, result_data)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -212,3 +212,11 @@ def test_build_ida_args_flag_in_options_without_structured_param():
     """Flags in options are allowed when the corresponding structured param is empty."""
     result = build_ida_args(options="-parm:ARMv7-M")
     assert result == "-parm:ARMv7-M"
+
+
+def test_build_ida_args_no_false_positive_on_longer_flags():
+    """Substring matches inside longer flags must not trigger conflict detection."""
+    # "-p" should not match inside "--prefer-something"
+    result = build_ida_args(processor="arm:ARMv7-M", options="--prefer-something")
+    assert "-parm:ARMv7-M" in result
+    assert "--prefer-something" in result

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -17,6 +17,7 @@ import pytest
 from ida_mcp.exceptions import (
     AMBIGUOUS_PROCESSORS,
     IDAError,
+    build_ida_args,
     check_processor_ambiguity,
 )
 
@@ -125,3 +126,89 @@ def test_ida_error_with_details():
     err = IDAError("bad", error_type="X", valid_values=["a", "b"])
     parsed = json.loads(str(err))
     assert parsed["valid_values"] == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# build_ida_args
+# ---------------------------------------------------------------------------
+
+
+def test_build_ida_args_empty():
+    """No parameters produces None."""
+    assert build_ida_args() is None
+
+
+def test_build_ida_args_processor_only():
+    assert build_ida_args(processor="arm:ARMv7-M") == "-parm:ARMv7-M"
+
+
+def test_build_ida_args_loader_only():
+    assert build_ida_args(loader="ELF") == "-TELF"
+
+
+def test_build_ida_args_loader_with_spaces():
+    """Loader names with spaces must be quoted."""
+    result = build_ida_args(loader="Binary file")
+    assert result == '-T"Binary file"'
+
+
+def test_build_ida_args_base_address_hex():
+    result = build_ida_args(base_address="0x20000")
+    assert result == "-b0x2000"
+
+
+def test_build_ida_args_base_address_decimal():
+    result = build_ida_args(base_address="131072")
+    # 131072 == 0x20000, paragraph = 0x2000
+    assert result == "-b0x2000"
+
+
+def test_build_ida_args_base_address_not_aligned():
+    with pytest.raises(IDAError, match="not 16-byte aligned"):
+        build_ida_args(base_address="0x20001")
+
+
+def test_build_ida_args_base_address_invalid():
+    with pytest.raises(IDAError, match="Invalid base_address"):
+        build_ida_args(base_address="not_a_number")
+
+
+def test_build_ida_args_all_params():
+    result = build_ida_args(
+        processor="arm:ARMv7-M",
+        loader="Binary file",
+        base_address="0x8000000",
+    )
+    assert result == '-parm:ARMv7-M -T"Binary file" -b0x800000'
+
+
+def test_build_ida_args_options_passthrough():
+    result = build_ida_args(options="-a")
+    assert result == "-a"
+
+
+def test_build_ida_args_combined_with_options():
+    result = build_ida_args(processor="arm:ARMv7-M", options="-a")
+    assert result == "-parm:ARMv7-M -a"
+
+
+def test_build_ida_args_conflicting_processor_in_options():
+    """options containing -p should be rejected when processor is set."""
+    with pytest.raises(IDAError, match="processor"):
+        build_ida_args(processor="arm:ARMv7-M", options="-pmetapc")
+
+
+def test_build_ida_args_conflicting_loader_in_options():
+    with pytest.raises(IDAError, match="loader"):
+        build_ida_args(loader="ELF", options="-TBinary")
+
+
+def test_build_ida_args_conflicting_base_in_options():
+    with pytest.raises(IDAError, match="base_address"):
+        build_ida_args(base_address="0x10000", options="-b0x100")
+
+
+def test_build_ida_args_flag_in_options_without_structured_param():
+    """Flags in options are allowed when the corresponding structured param is empty."""
+    result = build_ida_args(options="-parm:ARMv7-M")
+    assert result == "-parm:ARMv7-M"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: © 2026 Joe T. Sylve, Ph.D. <joe.sylve@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for exceptions.py — processor ambiguity detection and IDAError.
+
+These tests cover check_processor_ambiguity and PRIMARY_IDB_EXTENSIONS —
+all functions that can run without idalib.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ida_mcp.exceptions import (
+    AMBIGUOUS_PROCESSORS,
+    IDAError,
+    check_processor_ambiguity,
+)
+
+# ---------------------------------------------------------------------------
+# check_processor_ambiguity — should raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("processor", ["arm", "ARM", "Arm"])
+def test_ambiguous_arm_raw_binary(tmp_path, processor):
+    raw = tmp_path / "firmware.bin"
+    raw.write_bytes(b"\x00" * 16)
+    with pytest.raises(IDAError, match="AmbiguousProcessor"):
+        check_processor_ambiguity(processor, str(raw), force_new=False)
+
+
+@pytest.mark.parametrize("processor", ["metapc", "pc", "mips", "mipsl", "ppc", "riscv"])
+def test_ambiguous_processors(tmp_path, processor):
+    raw = tmp_path / "firmware.bin"
+    raw.write_bytes(b"\x00" * 16)
+    with pytest.raises(IDAError, match="AmbiguousProcessor"):
+        check_processor_ambiguity(processor, str(raw), force_new=False)
+
+
+def test_ambiguous_with_force_new_and_existing_db(tmp_path):
+    """force_new=True should still raise even when a sidecar .i64 exists."""
+    raw = tmp_path / "firmware.bin"
+    raw.write_bytes(b"\x00" * 16)
+    sidecar = tmp_path / "firmware.bin.i64"
+    sidecar.write_bytes(b"\x00")
+    with pytest.raises(IDAError):
+        check_processor_ambiguity("arm", str(raw), force_new=True)
+
+
+# ---------------------------------------------------------------------------
+# check_processor_ambiguity — should NOT raise
+# ---------------------------------------------------------------------------
+
+
+def test_variant_specified(tmp_path):
+    """Processor with a variant (colon) should not raise."""
+    raw = tmp_path / "firmware.bin"
+    raw.write_bytes(b"\x00" * 16)
+    check_processor_ambiguity("arm:ARMv7-M", str(raw), force_new=False)
+
+
+def test_no_processor():
+    """Empty processor (auto-detect) should not raise."""
+    check_processor_ambiguity("", "/some/file.bin", force_new=False)
+
+
+def test_opening_existing_idb(tmp_path):
+    """Opening an .i64 database should not raise regardless of processor."""
+    db = tmp_path / "firmware.i64"
+    db.write_bytes(b"\x00")
+    check_processor_ambiguity("arm", str(db), force_new=False)
+
+
+def test_opening_existing_idb_idb_ext(tmp_path):
+    """Opening an .idb database should not raise."""
+    db = tmp_path / "firmware.idb"
+    db.write_bytes(b"\x00")
+    check_processor_ambiguity("arm", str(db), force_new=False)
+
+
+def test_existing_sidecar_skips_check(tmp_path):
+    """When a sidecar .i64 exists and force_new=False, no ambiguity error."""
+    raw = tmp_path / "firmware.bin"
+    raw.write_bytes(b"\x00" * 16)
+    sidecar = tmp_path / "firmware.bin.i64"
+    sidecar.write_bytes(b"\x00")
+    check_processor_ambiguity("arm", str(raw), force_new=False)
+
+
+def test_unambiguous_processor(tmp_path):
+    """A processor not in the ambiguous set should not raise."""
+    raw = tmp_path / "firmware.bin"
+    raw.write_bytes(b"\x00" * 16)
+    check_processor_ambiguity("aarch64", str(raw), force_new=False)
+
+
+# ---------------------------------------------------------------------------
+# AMBIGUOUS_PROCESSORS coverage
+# ---------------------------------------------------------------------------
+
+
+def test_all_ambiguous_processors_have_hints():
+    """Every entry in AMBIGUOUS_PROCESSORS should have a non-empty hint."""
+    for proc, hint in AMBIGUOUS_PROCESSORS.items():
+        assert isinstance(hint, str) and len(hint) > 0, f"{proc} has empty hint"
+
+
+# ---------------------------------------------------------------------------
+# IDAError
+# ---------------------------------------------------------------------------
+
+
+def test_ida_error_str_json():
+    err = IDAError("something failed", error_type="TestError")
+    parsed = json.loads(str(err))
+    assert parsed["error"] == "something failed"
+    assert parsed["error_type"] == "TestError"
+
+
+def test_ida_error_with_details():
+    err = IDAError("bad", error_type="X", valid_values=["a", "b"])
+    parsed = json.loads(str(err))
+    assert parsed["valid_values"] == ["a", "b"]

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: © 2026 Joe T. Sylve, Ph.D. <joe.sylve@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the RestrictedPython sandbox.
+
+These tests cover basic execution, async/await, import controls,
+builtin availability, multiline strings, and blocked operations —
+all without idalib.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ida_mcp.sandbox import RestrictedPythonSandbox
+
+
+@pytest.fixture
+def sandbox():
+    return RestrictedPythonSandbox()
+
+
+# ---------------------------------------------------------------------------
+# Basic execution
+# ---------------------------------------------------------------------------
+
+
+def test_basic_expression(sandbox):
+    assert asyncio.run(sandbox.run("return 1 + 2")) == 3
+
+
+def test_variables_and_control_flow(sandbox):
+    code = """\
+total = 0
+for i in range(5):
+    total += i
+return total
+"""
+    assert asyncio.run(sandbox.run(code)) == 10
+
+
+def test_no_return_gives_none(sandbox):
+    assert asyncio.run(sandbox.run("x = 42")) is None
+
+
+def test_inputs_available(sandbox):
+    result = asyncio.run(sandbox.run("return x + 1", inputs={"x": 10}))
+    assert result == 11
+
+
+def test_external_functions(sandbox):
+    async def add(a, b):
+        return a + b
+
+    result = asyncio.run(
+        sandbox.run(
+            "return await add(3, 4)",
+            external_functions={"add": add},
+        )
+    )
+    assert result == 7
+
+
+# ---------------------------------------------------------------------------
+# Multiline strings — regression test for AST-level wrapping
+# ---------------------------------------------------------------------------
+
+
+def test_multiline_string_preserved(sandbox):
+    """Multiline string content must not be shifted by the wrapper."""
+    code = '''\
+x = """
+hello
+world
+"""
+return x
+'''
+    result = asyncio.run(sandbox.run(code))
+    assert result == "\nhello\nworld\n"
+
+
+def test_multiline_string_with_indentation(sandbox):
+    """Indentation inside multiline strings must be preserved exactly."""
+    code = '''\
+x = """
+    indented
+        more
+"""
+return x
+'''
+    result = asyncio.run(sandbox.run(code))
+    assert result == "\n    indented\n        more\n"
+
+
+# ---------------------------------------------------------------------------
+# Async / await
+# ---------------------------------------------------------------------------
+
+
+def test_await(sandbox):
+    async def fetch(key):
+        return {"key": key}
+
+    result = asyncio.run(
+        sandbox.run(
+            'return await fetch("test")',
+            external_functions={"fetch": fetch},
+        )
+    )
+    assert result == {"key": "test"}
+
+
+def test_asyncio_gather(sandbox):
+    async def double(x):
+        return x * 2
+
+    code = """\
+import asyncio
+results = await asyncio.gather(double(1), double(2), double(3))
+return list(results)
+"""
+    result = asyncio.run(sandbox.run(code, external_functions={"double": double}))
+    assert result == [2, 4, 6]
+
+
+# ---------------------------------------------------------------------------
+# Import controls
+# ---------------------------------------------------------------------------
+
+
+_ALLOWED_MODULES = [
+    "asyncio",
+    "collections",
+    "functools",
+    "itertools",
+    "json",
+    "math",
+    "operator",
+    "re",
+    "struct",
+    "typing",
+]
+
+
+@pytest.mark.parametrize("module", _ALLOWED_MODULES)
+def test_allowed_import(sandbox, module):
+    result = asyncio.run(sandbox.run(f"import {module}\nreturn True"))
+    assert result is True
+
+
+def test_submodule_import(sandbox):
+    code = "from collections.abc import Sequence\nreturn issubclass(list, Sequence)"
+    assert asyncio.run(sandbox.run(code)) is True
+
+
+def test_submodule_import_direct(sandbox):
+    code = "import collections.abc\nreturn issubclass(list, collections.abc.Sequence)"
+    assert asyncio.run(sandbox.run(code)) is True
+
+
+@pytest.mark.parametrize("module", ["os", "sys", "subprocess", "socket", "shutil"])
+def test_blocked_import(sandbox, module):
+    with pytest.raises(ImportError, match="not allowed"):
+        asyncio.run(sandbox.run(f"import {module}"))
+
+
+# ---------------------------------------------------------------------------
+# Builtins
+# ---------------------------------------------------------------------------
+
+
+def test_hex_builtin(sandbox):
+    assert asyncio.run(sandbox.run("return hex(255)")) == "0xff"
+
+
+def test_oct_builtin(sandbox):
+    assert asyncio.run(sandbox.run("return oct(8)")) == "0o10"
+
+
+def test_bin_builtin(sandbox):
+    assert asyncio.run(sandbox.run("return bin(10)")) == "0b1010"
+
+
+def test_int_base_conversion(sandbox):
+    assert asyncio.run(sandbox.run('return int("ff", 16)')) == 255
+
+
+def test_container_builtins(sandbox):
+    code = """\
+d = dict(a=1)
+s = set([1, 2, 3])
+return len(d) + len(s)
+"""
+    assert asyncio.run(sandbox.run(code)) == 4
+
+
+def test_struct_unpack(sandbox):
+    code = """\
+import struct
+return struct.unpack('<I', b'\\x01\\x00\\x00\\x00')[0]
+"""
+    assert asyncio.run(sandbox.run(code)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Blocked operations
+# ---------------------------------------------------------------------------
+
+
+def test_eval_blocked(sandbox):
+    with pytest.raises(SyntaxError):
+        asyncio.run(sandbox.run('eval("1")'))
+
+
+def test_exec_blocked(sandbox):
+    with pytest.raises(SyntaxError):
+        asyncio.run(sandbox.run('exec("x = 1")'))
+
+
+def test_open_blocked(sandbox):
+    with pytest.raises((SyntaxError, ImportError, NameError)):
+        asyncio.run(sandbox.run('open("/etc/passwd")'))
+
+
+def test_dunder_access_blocked(sandbox):
+    with pytest.raises(SyntaxError, match="invalid attribute name"):
+        asyncio.run(sandbox.run("return ().__class__.__bases__"))
+
+
+# ---------------------------------------------------------------------------
+# In-place operations
+# ---------------------------------------------------------------------------
+
+
+def test_inplace_add(sandbox):
+    code = """\
+x = 10
+x += 5
+return x
+"""
+    assert asyncio.run(sandbox.run(code)) == 15
+
+
+def test_inplace_list_extend(sandbox):
+    code = """\
+x = [1, 2]
+x += [3, 4]
+return x
+"""
+    assert asyncio.run(sandbox.run(code)) == [1, 2, 3, 4]

--- a/uv.lock
+++ b/uv.lock
@@ -415,11 +415,12 @@ wheels = [
 
 [[package]]
 name = "ida-mcp"
-version = "2.2.0.dev1"
+version = "2.2.0.dev2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["code-mode"] },
     { name = "mcp" },
+    { name = "restrictedpython" },
 ]
 
 [package.dev-dependencies]
@@ -434,6 +435,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", extras = ["code-mode"], specifier = ">=3.1,<3.3" },
     { name = "mcp", specifier = ">=1.26,<2" },
+    { name = "restrictedpython", specifier = ">=8.1,<9" },
 ]
 
 [package.metadata.requires-dev]
@@ -1091,6 +1093,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "restrictedpython"
+version = "8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/1c/aec08bcb4ab14a1521579fbe21ceff2a634bb1f737f11cf7f9c8bb96e680/restrictedpython-8.1.tar.gz", hash = "sha256:4a69304aceacf6bee74bdf153c728221d4e3109b39acbfe00b3494927080d898", size = 838331, upload-time = "2025-10-19T14:11:32.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/c0/3848f4006f7e164ee20833ca984067e4b3fc99fe7f1dfa88b4927e681299/restrictedpython-8.1-py3-none-any.whl", hash = "sha256:4769449c6cdb10f2071649ba386902befff0eff2a8fd6217989fa7b16aeae926", size = 27651, upload-time = "2025-10-19T14:11:30.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `processor`, `loader`, `base_address`, and `options` parameters to `open_database` for raw binary/firmware analysis — threaded through supervisor → worker_provider → worker
- Add processor ambiguity detection (`_check_processor_ambiguity`) that catches headless-mode pitfalls (ARM defaults to AArch64, x86/MIPS bitness dialogs suppressed)
- Add `list_targets` management tool to enumerate available processor modules and loaders from the IDA installation
- Replace `MontySandboxProvider` with `RestrictedPythonSandbox` — supports async/await, broader import whitelist (`struct`, `collections`, `functools`, etc.)
- Add `load_additional_binary` tool for loading firmware overlays/components into an existing database
- Update supervisor instructions with call-pattern guidance and raw binary tips

## Test plan
- [ ] Open a raw ARM binary with `processor: "arm:ARMv7-M"` and verify correct disassembly
- [ ] Verify `list_targets` returns processor and loader lists
- [ ] Confirm bare `processor: "arm"` on a raw binary raises `AmbiguousProcessor` error
- [ ] Test `load_additional_binary` with a firmware overlay
- [ ] Verify `execute` code blocks still work with the new RestrictedPython sandbox (async/await, imports)
- [ ] Run `uv run ruff check src/` and `uv run pytest` clean