### PR TITLE
Fat Mach-O support and sandbox policy expansion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ uv run ruff format src/          # Format
 uv run ruff check --fix src/     # Lint with auto-fix
 ```
 
-Pre-commit hooks run reuse lint, ruff lint (with `--fix --exit-non-zero-on-fix`), ruff format, idalib threading lint (`scripts/lint_ida_threading.py`), and pytest on commit.
+Pre-commit hooks run REUSE compliance checks, ruff lint (with `--fix --exit-non-zero-on-fix`), ruff format, idalib threading lint (`scripts/lint_ida_threading.py`), and pytest on commit.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If the server can't find IDA, you'll get a clear error message telling you to se
 
 ## Usage
 
-### Stdio transport (default)
+### Running the server
 
 ```bash
 uvx ida-mcp
@@ -174,21 +174,22 @@ close_database(database="second")                       # closes second
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `IDADIR` | *(auto-detected)* | Path to IDA Pro installation directory |
-| `IDA_MCP_MAX_WORKERS` | *(no limit)* | Maximum simultaneous databases (1-8, unset for unlimited) |
+| `IDA_MCP_MAX_WORKERS` | *(unlimited)* | Maximum simultaneous databases (clamped to 1-8 when set) |
 | `IDA_MCP_ALLOW_SCRIPTS` | *(unset)* | Set to `1`, `true`, or `yes` to enable the `run_script` tool for arbitrary IDAPython execution |
 | `IDA_MCP_LOG_LEVEL` | `WARNING` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) — output goes to stderr |
+| `IDA_MCP_WORKER_LOG` | *(unset)* | Path to a file that receives each worker's stderr (defaults to inheriting the supervisor's stderr) |
 
 ## Tools
 
-To keep token usage manageable, only a set of common analysis tools are directly visible to clients. Three meta-tools handle the rest:
+To keep token usage manageable, only common analysis tools and management tools are directly visible to clients. The rest remain callable by name and can be discovered or batched through three meta-tools:
 
-- **`search_tools`** — regex search over tool names, descriptions, and tags (searches non-pinned tools; pinned tools are already visible)
-- **`execute`** — sandboxed Python that chains multiple `await call_tool` invocations in a single round trip (supports `asyncio.gather` for parallel queries, loops, and result processing)
-- **`batch`** — sequential multi-tool execution with per-item error collection and progress reporting (up to 50 operations per call)
+- **`search_tools`** — regex search over non-pinned tool names, descriptions, and tags (pinned tools are already visible).
+- **`execute`** — sandboxed Python that chains multiple `await call_tool` invocations in a single round trip. Supports `asyncio.gather` for parallel queries, loops, and conditional logic between calls.
+- **`batch`** — sequential multi-tool execution with per-item error collection and progress reporting (up to 50 operations per call).
 
-Tools not in the pinned set are hidden from the listing but remain callable by name. Management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`, `list_targets`) are always visible.
+Management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`, `list_targets`) are always visible and must be called directly — not through `execute` or `batch`.
 
-The full tool catalog covers all major areas of IDA Pro's functionality:
+The full tool catalog spans these areas:
 
 - **Database** — open/close/save/list databases, file region mapping, metadata
 - **Functions** — list, query, decompile, disassemble, rename, prototypes, chunks, stack frames
@@ -226,7 +227,7 @@ See [docs/tools.md](docs/tools.md) for the complete tools reference.
 
 ## Resources
 
-The server exposes [MCP resources](https://modelcontextprotocol.io/docs/concepts/resources) — read-only, cacheable context endpoints that provide structured data without consuming tool calls:
+The server exposes [MCP resources](https://modelcontextprotocol.io/docs/concepts/resources) — read-only, cacheable endpoints for structured database context:
 
 - **Static binary data** — imports, exports, entry points (with regex search variants)
 - **Aggregate snapshot** — statistics (function/segment/entry point/string/name counts, code coverage)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,6 +170,7 @@ Tools return Pydantic model instances on success (FastMCP serializes these autom
 - `AmbiguousProcessor` — raw binary opened with a bitness-ambiguous processor module (e.g. bare `arm`); fix by passing a variant like `arm:ARMv7-M`
 - `AmbiguousFatBinary` — Mach-O universal binary opened without `fat_arch`; the error's `available` detail lists the slices
 - `UnknownFatArch` — `fat_arch` value not present in the fat binary; the error's `available` detail lists the valid slices
+- `DuplicateFatSlice` — fat binary contains two slices that resolve to the same lipo-style architecture name; run `lipo -thin` to extract the intended slice and reopen the thin file
 
 Individual tools define additional error types specific to their domain (e.g. `ParseError`, `DecodeFailed`, `SetCommentFailed`).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,13 +39,15 @@ The trade-off is that idalib is **single-threaded**: all IDA API calls must happ
 [FastMCP](https://gofastmcp.com) provides a decorator-based API for defining MCP tools. Each tool is a plain Python function with type annotations — FastMCP handles JSON schema generation, argument validation, and transport.
 
 The server uses stdio transport (not SSE/HTTP) because:
-- MCP clients like Claude Desktop expect stdio
+- It is the most widely supported transport across MCP clients (Claude Desktop, Cursor, etc.)
 - No port management or auth needed
 - Process lifecycle is tied to the client session
 
 ### Main-thread execution (`IDAServer`)
 
-idalib is thread-affine: the `idapro` import and all subsequent IDA API calls must happen on the main OS thread. The MCP event loop runs on a daemon background thread, while the main thread runs a `MainThreadExecutor` work queue. The `IDAServer` subclass in `server.py` wraps every sync tool and resource function registered via `@mcp.tool()` or `@mcp.resource()` into an `async def` that dispatches the call to the main thread via `call_ida` (backed by `MainThreadExecutor`). FastMCP sees an async function and skips its own threadpool. This ensures all IDA API calls execute on the main thread while keeping the MCP server responsive. Async tool functions run on the event-loop thread and must use `call_ida` for individual IDA API calls.
+idalib is thread-affine: the `idapro` import and all subsequent IDA API calls must happen on the main OS thread. The MCP event loop runs on a daemon background thread, while the main thread runs a `MainThreadExecutor` work queue.
+
+The `IDAServer` subclass in `server.py` wraps every sync tool and resource function registered via `@mcp.tool()` or `@mcp.resource()` into an `async def` that dispatches the call to the main thread via `call_ida` (backed by `MainThreadExecutor`). FastMCP sees an async function and skips its own threadpool, so all IDA API calls land on the main thread while the MCP server remains responsive. Async tool functions run on the event-loop thread and must use `call_ida` for individual IDA API calls.
 
 Functions in `helpers.py` that contain IDA API calls are marked with `@ida_dispatch`. This decorator tags the function with a `_ida_dispatch` attribute (it does not alter execution) and signals that the function must be invoked via `call_ida` from async code. A pre-commit lint script (`scripts/lint_ida_threading.py`) enforces this: it checks that `@ida_dispatch`-marked functions are not called directly from async functions without going through `call_ida`.
 
@@ -73,7 +75,7 @@ session = Session()  # module-level singleton (one per worker process)
 
 Key behaviors:
 - Each worker process handles one database (idalib is single-threaded with global state)
-- Opening a new database auto-closes the previous one (with save)
+- Calling `Session.open()` on a worker that already has a database open auto-closes the previous one with save (the supervisor spawns a fresh worker per database, so this path is only hit in standalone worker use)
 - `session.require_open` is a decorator that raises `IDAError` if no database is open. Since `IDAError` subclasses fastmcp's `ToolError`, fastmcp automatically returns `isError=True` with the message as text content
 - The decorator also clears IDA's cancellation flag before each call and catches `Cancelled` exceptions, re-raising them as `IDAError`
 - The worker's `main()` function calls `session.close(save=True)` in its `finally` block on shutdown
@@ -86,7 +88,17 @@ Key behaviors:
 
 The supervisor uses FastMCP's native Provider system to expose worker tools and resources through the standard provider chain, rather than overriding `list_tools()`, `call_tool()`, etc.
 
-**`ProxyMCP`** (`supervisor.py`) subclasses `FastMCP`. It creates a `WorkerPoolProvider` and calls `self.add_provider(worker_pool)`. Management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`, `list_targets`) and the `ida://databases` resource are registered directly on the `FastMCP` server via its internal `_local_provider`. Prompts are also registered directly (they don't require database state). An `IDAToolTransform` (a `CatalogTransform` subclass defined in `transforms.py`) is applied at the server level. It pins a set of common analysis tools (e.g. `list_functions`, `decompile_function`, `get_strings`) alongside three meta-tools: `search_tools` (regex discovery of all other tools), `execute` (sandboxed Python that chains `await call_tool` invocations for multi-step pipelines and parallel queries), and `batch` (sequential multi-tool execution with per-item error collection). Tools not in the pinned set are hidden from the tool listing but remain callable by name. Management tools delegate to `WorkerPoolProvider` methods for worker lifecycle and are session-aware: `close_database` delegates to `close_for_session()` which atomically detaches and conditionally terminates under `_lock`; `save_database` checks attachment before proceeding. A `_session_id()` helper uses `try_get_context()` (from `context.py`) to extract the session ID without exposing a `ctx` parameter in the tool schema.
+**`ProxyMCP`** (`supervisor.py`) subclasses `FastMCP`. It creates a `WorkerPoolProvider` and calls `self.add_provider(worker_pool)`. Management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`, `list_targets`), prompts, and the `ida://databases` resource are registered directly on the supervisor — they do not require database state and are served by FastMCP's internal local provider.
+
+An `IDAToolTransform` (a `CatalogTransform` subclass defined in `transforms.py`) is applied at the server level. It pins a set of common analysis tools (e.g. `list_functions`, `decompile_function`, `get_strings`) alongside three meta-tools:
+
+- `search_tools` — regex discovery over all non-pinned tools.
+- `execute` — sandboxed Python that chains `await call_tool` invocations for multi-step pipelines and parallel queries.
+- `batch` — sequential multi-tool execution with per-item error collection.
+
+Tools not in the pinned set are hidden from the tool listing but remain callable by name.
+
+Management tools delegate to `WorkerPoolProvider` methods for worker lifecycle and are session-aware: `close_database` delegates to `close_for_session()`, which atomically detaches and conditionally terminates under `_lock`; `save_database` checks attachment before proceeding. A `_session_id()` helper uses `try_get_context()` (from `context.py`) to extract the session ID without exposing a `ctx` parameter in the tool schema.
 
 **`WorkerPoolProvider`** (`worker_provider.py`) implements FastMCP's `Provider` interface. It manages worker subprocesses (each via a `fastmcp.Client` with `StdioTransport`) and exposes their tools and resources through the provider chain:
 
@@ -97,28 +109,51 @@ The supervisor uses FastMCP's native Provider system to expose worker tools and 
 - `check_attached(worker, session_id)` raises `IDAError` if the session is not attached to the worker (pass-through when session ID is `None` or the worker has no tracked sessions for backward compatibility).
 - `close_for_session(worker, session_id, save, force)` atomically checks attachment, detaches, and conditionally terminates under `_lock` — prevents races where a concurrent `attach()` from `RoutingTool.run()` could sneak in between detach and terminate.
 - `detach_all(session_id, save=True)` detaches a session from all workers under `_lock`, terminating any whose session set becomes empty; falls back to `shutdown_all()` when session ID is `None`.
-- `build_database_list(include_state, caller_session_id)` returns all open databases with metadata; when `caller_session_id` is provided, each entry includes an `attached` flag and `session_count`.
+- `build_database_list(include_state, caller_session_id)` returns all open databases with metadata and a `session_count` per entry; when `caller_session_id` is provided, each entry also includes an `attached` flag.
 
 Tool/resource schemas are bootstrapped lazily from a temporary worker on first access. `RoutingTool` and `RoutingTemplate` both set `task_config = TaskConfig(mode="optional")`.
 
-All tools except management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`, `list_targets`) require the `database` parameter (the stem ID returned by `open_database`).
+All tools except management tools (`open_database`, `close_database`, `save_database`, `list_databases`, `wait_for_analysis`, `list_targets`) require the `database` parameter (the stem ID returned by `open_database` or `list_databases`).
 
 #### Background analysis
 
-When `open_database(run_auto_analysis=True)` is called, `spawn_worker()` opens the database without analysis, then starts a background `asyncio.Task` (via `Worker.start_analysis()`) that dispatches `wait_for_analysis` through the normal proxy path. The response includes `"analyzing": true` so the client knows analysis is in progress. While background analysis is running, all tools are blocked except `wait_for_analysis` — the IDA thread is occupied by `auto_wait()`. `wait_for_analysis` blocks until analysis finishes. After analysis completes, worker metadata (function count, etc.) is refreshed via `get_database_info`, and MCP log and resource-list-changed notifications are sent if an `mcp_session` is available. Clients should call `wait_for_analysis` on the database to block until completion rather than polling `list_databases`. Background analysis tasks are cancelled during worker shutdown.
+`spawn_worker()` returns immediately. The worker subprocess, database open, and optional auto-analysis all run in a background `asyncio.Task` (`_background_spawn`). The initial response includes `"opening": true`, and callers must call `wait_for_analysis` to block until the database is ready for tool calls.
+
+When `run_auto_analysis=True`, `_background_spawn` chains into a second task (via `Worker.start_analysis()`) that dispatches `wait_for_analysis` through the normal proxy path once the open completes. While that task runs, `list_databases` reports `"analyzing": true` for the worker.
+
+While background analysis is running, every worker tool except `wait_for_analysis` is rejected by `RoutingTool.run()` — the IDA thread is occupied by `auto_wait()`. `wait_for_analysis` awaits the background task directly rather than making a redundant proxy call.
+
+After analysis completes, worker metadata (function count, etc.) is refreshed via `get_database_info`, and MCP log and resource-list-changed notifications are sent if an `mcp_session` is available. Clients should call `wait_for_analysis` on the database to block until completion rather than polling `list_databases`. Background spawn and analysis tasks are cancelled during worker shutdown.
+
+#### Fat Mach-O binaries
+
+Mach-O universal ("fat") binaries contain multiple architecture slices. Before spawning a worker, `open_database` calls `check_fat_binary` (in `exceptions.py`), which parses the on-disk `FAT_MAGIC` / `FAT_MAGIC_64` header via `detect_fat_slices` and refuses to proceed without an explicit `fat_arch` parameter — headless idalib would otherwise silently pick a default slice. The resulting `IDAError` uses `error_type="AmbiguousFatBinary"` and includes an `available` detail listing the slice names (`x86_64`, `arm64`, `arm64e`, ...).
+
+`check_fat_binary` returns the slice's 1-based position in the on-disk fat header, which `build_ida_args` emits as `-T"Fat Mach-O file, <index>"` — the only documented way to pick a slice in headless mode. Because the fat-slice selector already uses `-T`, `loader` cannot be combined with `fat_arch`.
+
+Per-slice sidecars are stored at `<binary>.<arch>.i64` (via an `-o<stem>` override in `session.open`) so multiple architectures of the same universal binary coexist on disk. The check short-circuits on existing `.i64`/`.idb` databases (and on matching per-slice sidecars unless `force_new=True`), since stored analysis already pins a slice. To analyze multiple slices from the same file concurrently, open once per slice with distinct `database_id` values.
 
 #### Per-worker concurrency
 
-Because idalib is single-threaded, requests to the same worker are serialized by the worker's single-threaded MCP transport. The `dispatch()` async context manager tracks active call count and activity timestamps. Requests to *different* workers run fully in parallel. The `Worker.state` property derives the effective state (BUSY/IDLE) from the `_active_calls` counter rather than requiring manual state transitions. Crashed workers are detected on-demand when tool calls or resource reads encounter connection errors (`ClosedResourceError`, `EndOfStream`, `BrokenPipeError`/`OSError`, `McpError` with connection-closed code) — `proxy_to_worker()` and `RoutingTemplate._read()` call `mark_worker_dead()` to clean up.
+Because idalib is single-threaded, requests to the same worker are serialized by the worker's single-threaded MCP transport. The `dispatch()` async context manager tracks active call count and activity timestamps. Requests to *different* workers run fully in parallel. The `Worker.state` property derives the effective state (BUSY/IDLE) from the `_active_calls` counter rather than requiring manual state transitions.
+
+Crashed workers are detected on-demand when tool calls or resource reads encounter connection errors (`ClosedResourceError`, `EndOfStream`, `BrokenPipeError`/`OSError`, `McpError` with connection-closed code) — `proxy_to_worker()` and `RoutingTemplate._read()` call `mark_worker_dead()` to clean up.
 
 #### Session tracking
 
-Workers track which MCP sessions are using them via `attach(session_id)` / `detach(session_id)` / `is_attached(session_id)` / `session_count`. Sessions are attached implicitly when a tool or resource is accessed (via `attach_current_session()`, called from `RoutingTool.run()` and `RoutingTemplate._read()`) and explicitly on `open_database`. `close_database` delegates to `close_for_session()` which atomically checks attachment, detaches, and conditionally terminates under `_lock`. When other sessions are still using the database, it returns a `detached` status instead of terminating. `save_database` and `close_database` check attachment before proceeding (unless `force=True`). When an MCP session disconnects, a cleanup callback registered on the session's exit stack automatically detaches the session from all workers (via `detach_all`), terminating any workers that have no remaining sessions.
+Workers track which MCP sessions are using them via `attach(session_id)` / `detach(session_id)` / `is_attached(session_id)` / `session_count`. Sessions are attached implicitly when a tool or resource is accessed (via `attach_current_session()`, called from `RoutingTool.run()` and `RoutingTemplate._read()`) and explicitly on `open_database`.
 
-Configuration environment variables:
-- `IDA_MCP_MAX_WORKERS` — maximum simultaneous databases (1-8, unlimited when unset)
+`close_database` delegates to `close_for_session()`, which atomically checks attachment, detaches, and conditionally terminates under `_lock`. When other sessions are still using the database, it returns a `detached` status instead of terminating. `save_database` and `close_database` check attachment before proceeding (unless `force=True`).
+
+When an MCP session disconnects, a cleanup callback registered on the session's exit stack automatically detaches the session from all workers (via `detach_all`), terminating any workers that have no remaining sessions.
+
+#### Configuration environment variables
+
+- `IDA_MCP_MAX_WORKERS` — maximum simultaneous databases (clamped to 1-8 when set; unlimited when unset)
 - `IDA_MCP_ALLOW_SCRIPTS` — enables the `run_script` tool for arbitrary IDAPython execution (set to `1`, `true`, or `yes`)
 - `IDA_MCP_LOG_LEVEL` — logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`); defaults to `WARNING`, output goes to stderr
+- `IDADIR` — path to the IDA Pro installation directory (auto-detected when unset)
+- `IDA_MCP_WORKER_LOG` — path to a file that receives each worker's stderr (defaults to inheriting the supervisor's stderr)
 
 ### Error handling convention
 
@@ -132,6 +167,9 @@ Tools return Pydantic model instances on success (FastMCP serializes these autom
 - `DecompilationFailed` — Hex-Rays decompilation error
 - `InvalidArgument` — bad parameter value
 - `Cancelled` — operation cancelled via cooperative cancellation
+- `AmbiguousProcessor` — raw binary opened with a bitness-ambiguous processor module (e.g. bare `arm`); fix by passing a variant like `arm:ARMv7-M`
+- `AmbiguousFatBinary` — Mach-O universal binary opened without `fat_arch`; the error's `available` detail lists the slices
+- `UnknownFatArch` — `fat_arch` value not present in the fat binary; the error's `available` detail lists the valid slices
 
 Individual tools define additional error types specific to their domain (e.g. `ParseError`, `DecodeFailed`, `SetCommentFailed`).
 
@@ -144,7 +182,7 @@ Addresses are the most common parameter type. The `parse_address` function in `h
 1. `"0x401000"` — hex with `0x` prefix (unambiguous, tried first)
 2. `"4198400"` — decimal (all-digit strings are always decimal)
 3. `"main"` — symbol name (resolved via IDA's name database)
-4. `"4010a0"` — bare hex fallback (tried last, only if the string contains a-f)
+4. `"4010a0"` — bare hex fallback (last resort; reached only when the string is not pure digits and is not a known symbol)
 
 Symbol names are checked before bare hex so that names like `add`, `dead`, or `cafe` resolve to the named symbol rather than being parsed as hexadecimal. Use the `0x` prefix for explicit hex (e.g. `0xADD` instead of `add`).
 
@@ -186,14 +224,14 @@ The default limit is 100 for most tools. Some tools use smaller defaults: 50 for
 | `server.py` | Worker entry point (`ida-mcp-worker`) — creates `IDAServer` (a `FastMCP` subclass), auto-discovers and registers all tool modules from `tools/`, runs stdio transport |
 | `session.py` | Database session singleton (per worker), `require_open` decorator |
 | `context.py` | `try_get_context()` — idalib-safe FastMCP context accessor, used by both supervisor and workers |
-| `exceptions.py` | `IDAError(ToolError)` — structured error type, plus idalib-safe validation utilities (`build_ida_args`, `check_processor_ambiguity`, `AMBIGUOUS_PROCESSORS`, `PRIMARY_IDB_EXTENSIONS`) |
+| `exceptions.py` | `IDAError(ToolError)` — structured error type, plus idalib-safe validation utilities (`build_ida_args`, `check_processor_ambiguity`, `check_fat_binary`, `detect_fat_slices`, `AMBIGUOUS_PROCESSORS`, `PRIMARY_IDB_EXTENSIONS`) |
 | `helpers.py` | Address parsing, formatting, pagination, resolution helpers, string decoding, MCP annotation presets, meta presets, `Annotated` parameter type aliases, `call_ida` main-thread dispatch, `@ida_dispatch` marker |
-| `models.py` | Shared Pydantic models used across multiple tool modules (e.g. `PaginatedResult`, `FunctionSummary`, `RenameResult`); tool-specific models live in their respective tool modules. FastMCP derives and emits the JSON schema from return type annotations in tool definitions |
+| `models.py` | Shared Pydantic models used by multiple tool modules (e.g. `PaginatedResult`, `FunctionSummary`, `RenameResult`). Tool-specific models live in their respective tool modules; FastMCP derives the JSON output schema from each tool's return type annotation |
 | `sandbox.py` | `RestrictedPythonSandbox` — AST-restricted Python execution for the `execute` meta-tool |
 | `transforms.py` | `IDAToolTransform(CatalogTransform)` — pins common tools, adds `search_tools`, `execute`, and `batch` meta-tools, hides the rest from listing while keeping them callable by name |
 | `resources.py` | MCP resources — read-only, cacheable context endpoints (static binary data + aggregate statistics) |
 | `prompts/` | MCP prompt templates for guided analysis workflows (analysis, security, workflow) |
-| `__init__.py` | Lazy `bootstrap()` function to initialize idapro |
+| `__init__.py` | Lazy `bootstrap()` to initialize idapro, plus `find_ida_dir()` / `configure_logging()` for installation discovery and stderr logging |
 
 ### Tool modules (`tools/`)
 
@@ -217,7 +255,7 @@ def register(mcp: FastMCP):
 
 Key conventions:
 - All `ida_*` imports are top-level (safe because `server.py` calls `bootstrap()` before importing tool modules). Tool modules are auto-discovered via `pkgutil.iter_modules` — any `tools/*.py` with a `register(mcp)` function is loaded automatically
-- `@session.require_open` is applied to all worker tools that need a database (everything except `convert_number`). Management tools (`open_database`, `close_database`, `list_targets`, etc.) live on the supervisor, not in worker tool modules
+- `@session.require_open` is applied to all worker tools that need a database. The exceptions are `convert_number` (no database needed) and the worker-side `open_database` / `close_database` (lifecycle tools that manage the session themselves). The supervisor exposes its own session-aware versions of `open_database`, `close_database`, `save_database`, and `wait_for_analysis` and proxies the latter two to the worker implementations; `list_databases` and `list_targets` are supervisor-only and have no worker equivalent
 - Every tool has MCP annotations (`ANNO_READ_ONLY`, `ANNO_MUTATE`, `ANNO_MUTATE_NON_IDEMPOTENT`, or `ANNO_DESTRUCTIVE`) and `tags=` for categorical grouping. Tools may also have `meta=` presets (`META_DECOMPILER`, `META_BATCH`, `META_READS_FILES`, `META_WRITES_FILES`) for static metadata
 - Use `Annotated` type aliases (`Address`, `Offset`, `Limit`, `FilterPattern`, `OperandIndex`, `HexBytes`) for parameter types — they embed descriptions and validation constraints (e.g. `ge=0`, `ge=1`) directly into the JSON schema
 - Tool docstrings are sent to the LLM as tool descriptions — they should be clear and concise
@@ -287,7 +325,7 @@ The supervisor also owns one resource (`ida://databases`) that lists all open da
 
 ### Resource proxying
 
-Worker resources are exposed through `RoutingTemplate` instances in the `WorkerPoolProvider`. Each `RoutingTemplate` stores the original worker URI template as `_backend_uri_template` and presents a prefixed version with `{database}` to clients (e.g. `ida://functions/{addr}` becomes `ida://{database}/functions/{addr}`). At read time, `_read()` pops `database` from the params to resolve the worker, then reconstructs the backend URI from the stored template with the remaining params. The supervisor's own `ida://databases` resource is registered directly on the `FastMCP` server and is served by the internal `_local_provider` — the provider chain handles routing automatically.
+Worker resources are exposed through `RoutingTemplate` instances in the `WorkerPoolProvider`. Each `RoutingTemplate` stores the original worker URI template as `_backend_uri_template` and presents a prefixed version with `{database}` to clients (e.g. `ida://idb/imports{?offset,limit}` becomes `ida://{database}/idb/imports{?offset,limit}`). At read time, `_read()` pops `database` from the params to resolve the worker, then reconstructs the backend URI from the stored template with the remaining params. The supervisor's own `ida://databases` resource is registered directly on the `FastMCP` server and served by FastMCP's internal local provider — the provider chain handles routing automatically.
 
 ## Prompts
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,7 +4,7 @@ Complete reference for all tools provided by the IDA MCP Server.
 
 ## Tool Discovery
 
-To keep token usage manageable, only a set of common analysis tools and management tools are directly visible to clients. Three meta-tools handle discovery and batching of the full catalog:
+To keep token usage manageable, only common analysis tools and management tools are directly visible to clients. Three meta-tools handle discovery and batching of the full catalog:
 
 | Tool | Description |
 |------|-------------|
@@ -34,9 +34,9 @@ Core database lifecycle management.
 
 | Tool | Description |
 |------|-------------|
-| `open_database` | Open a binary file or existing IDA database (`.i64`/`.idb`) for analysis. Must be called before any analysis tool. By default, previously opened databases from this session remain open; pass `keep_open=False` to save and close databases owned by the current session first. Use `database_id` to assign a custom identifier. Returns immediately — the database is not ready for tool calls until `wait_for_analysis` returns. When `run_auto_analysis=True`, `wait_for_analysis` also waits for IDA's auto-analysis to complete. Pass `force_new=True` to delete any existing database files and start fresh (destructive). |
-| `close_database` | Close a database, optionally saving changes. Use `database` to specify which when multiple are open. |
-| `save_database` | Save a database without closing it. Use `database` to specify which when multiple are open. |
+| `open_database` | Open a binary file or existing IDA database (`.i64`/`.idb`) for analysis. Must be called before any analysis tool. By default, previously opened databases from this session remain open; pass `keep_open=False` to save and close databases owned by the current session first. Use `database_id` to assign a custom identifier. Returns immediately — the database is not ready for tool calls until `wait_for_analysis` returns. When `run_auto_analysis=True`, `wait_for_analysis` also waits for IDA's auto-analysis to complete. Pass `force_new=True` to delete any existing database files and start fresh (destructive). Optional `processor`, `loader`, `base_address`, and `options` override IDA's auto-detection for raw binaries (see `list_targets` for available modules). Mach-O universal binaries require an explicit `fat_arch` (e.g. `x86_64`, `arm64`, `arm64e`). |
+| `close_database` | Close a database, optionally saving changes. When other sessions are still attached, detaches the current session and keeps the worker alive. Use `force=True` to close regardless of other sessions. |
+| `save_database` | Save a database without closing it. Fails if the database is not attached to the current session unless `force=True`. |
 | `list_databases` | List all currently open databases with metadata (file path, processor, bitness, etc.). Includes `opening` and `analyzing` flags for databases that are still loading or being analyzed. |
 | `get_database_info` | Get metadata: file path, processor, bitness, file type, address range, counts. |
 | `get_database_paths` | Get file paths associated with current database (input file, IDB, ID0). |
@@ -114,7 +114,7 @@ Cross-reference queries and call graph analysis.
 |------|-------------|
 | `get_xrefs_to` | Get all references TO an address (what references it). For multiple addresses, use the `batch` meta-tool. Paginated. |
 | `get_xrefs_from` | Get all references FROM an address (what it references). Paginated. |
-| `get_call_graph` | Get the call graph for a function — callers and callees, up to 3 levels deep. |
+| `get_call_graph` | Get the call graph for a function — callers and callees. `depth` controls traversal (1-3, default 1). |
 
 ## Cross-Reference Manipulation
 
@@ -263,7 +263,7 @@ Hex-Rays AST (ctree) exploration and pattern matching.
 
 | Tool | Description |
 |------|-------------|
-| `get_ctree` | Get the decompiler AST for a function (configurable depth, max 10). |
+| `get_ctree` | Get the decompiler AST for a function. `depth` is 1-10 (default 3). |
 | `find_ctree_calls` | Find function calls in the AST, optionally filtered by callee name. |
 | `find_ctree_patterns` | Find patterns in the AST: calls, string_refs, comparisons, assignments, casts, pointer_derefs, or all. |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ida-mcp"
-version = "2.2.0.dev2"
+version = "2.2.0.dev3"
 description = "Headless IDA Pro MCP server using idalib"
 readme = "README.md"
 license = "MIT"

--- a/src/ida_mcp/context.py
+++ b/src/ida_mcp/context.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 def try_get_context() -> Context | None:
     """Return the current FastMCP ``Context``, or ``None`` outside a request.
 
-    Safe to call anywhere -- never raises.  Use this in shared helpers that
+    Safe to call anywhere — never raises.  Use this in shared helpers that
     want to report progress or log without requiring a context parameter.
     """
     try:

--- a/src/ida_mcp/exceptions.py
+++ b/src/ida_mcp/exceptions.py
@@ -119,8 +119,13 @@ def slice_sidecar_stem(file_path: str, fat_arch: str = "") -> str:
     an ``.i64`` / ``.idb``, the stem is the path with the extension
     stripped — *fat_arch* is ignored because the stored DB already pins
     the slice.
+
+    Uses :func:`os.path.realpath` (not just ``abspath``) so that two
+    symlinks pointing at the same binary produce the same stem, keeping
+    this in lock-step with :func:`worker_provider._canonical_path`'s
+    dedup key.
     """
-    resolved = os.path.abspath(os.path.expanduser(file_path))
+    resolved = os.path.realpath(os.path.expanduser(file_path))
     base, ext = os.path.splitext(resolved)
     if ext.lower() in PRIMARY_IDB_EXTENSIONS:
         return base
@@ -203,7 +208,8 @@ def build_ida_args(
     Returns ``None`` when no arguments are needed.  Raises :class:`IDAError`
     on invalid *base_address*, on a *loader* / *fat_slice_index* conflict,
     or when *options* duplicates a flag that is already provided by a
-    structured parameter.
+    structured parameter.  ``-o`` is also reserved — :meth:`Session.open`
+    owns it for fresh fat-slice sidecar redirection.
 
     When *fat_slice_index* is set it overrides *loader*: IDA's ``-T``
     flag is emitted as ``-T"Fat Mach-O file, <index>"``, which is the
@@ -232,6 +238,8 @@ def build_ida_args(
     # Reject options that duplicate a structured parameter already in use.
     # Match flags only at the start of the string or after whitespace to
     # avoid false positives on longer flags (e.g. "-p" inside "--prefer").
+    # ``-o`` is reserved unconditionally — owned by Session.open's
+    # per-slice sidecar redirect.
     if options:
         for flag, value, param_name in (
             ("-p", processor, "processor"),
@@ -244,6 +252,13 @@ def build_ida_args(
                     f"of passing '{flag}' in options to avoid duplicate flags.",
                     error_type="InvalidArgument",
                 )
+        if re.search(r"(?:^|\s)-o", options):
+            raise IDAError(
+                "options contains '-o' — the -o<stem> flag is reserved "
+                "for Session.open's per-slice sidecar redirection and "
+                "must not be passed through the options parameter.",
+                error_type="InvalidArgument",
+            )
 
     args_parts: list[str] = []
     if processor:
@@ -301,10 +316,11 @@ _CPU_TYPE_NAMES: dict[int, str] = {
     0x01000012: "ppc64",
 }
 
-# XNU's CPU_SUBTYPE_MASK (0xFF000000) marks the feature-flag bits; we
-# AND with its inverse to keep just the architecture subtype id before
-# comparison.
-_CPU_SUBTYPE_MASK = 0x00FFFFFF
+# XNU's CPU_SUBTYPE_MASK (see ``mach/machine.h``) covers the top 8 bits
+# of the cpusubtype field, where feature flags live — the low 24 bits
+# hold the actual subtype identifier (e.g. CPU_SUBTYPE_ARM64E).  Named
+# to match the XNU header so readers can grep across both sources.
+_CPU_SUBTYPE_MASK = 0xFF000000
 
 # Well-known cpusubtype refinements we want to surface as distinct names,
 # matching lipo(1)'s output.  Key is (cputype, cpusubtype & mask).
@@ -328,7 +344,7 @@ def _fat_slice_name(cputype: int, cpusubtype: int) -> str | None:
     """
     if cputype not in _CPU_TYPE_NAMES:
         return None
-    sub = cpusubtype & _CPU_SUBTYPE_MASK
+    sub = cpusubtype & ~_CPU_SUBTYPE_MASK
     return _CPU_SUBTYPE_NAMES.get((cputype, sub)) or _CPU_TYPE_NAMES[cputype]
 
 
@@ -409,9 +425,9 @@ def check_fat_binary(file_path: str, fat_arch: str, force_new: bool) -> int | No
     if _has_stored_analysis(file_path, force_new, fat_arch):
         return None
 
-    # detect_fat_slices opens the file directly, so tilde-paths must be
-    # expanded here (Python's open() does not expand ~).
-    slices = detect_fat_slices(os.path.abspath(os.path.expanduser(file_path)))
+    # detect_fat_slices opens the file directly; realpath+expanduser so
+    # the parser sees the same file as slice_sidecar_stem's dedup key.
+    slices = detect_fat_slices(os.path.realpath(os.path.expanduser(file_path)))
     if slices is None:
         if fat_arch:
             raise IDAError(

--- a/src/ida_mcp/exceptions.py
+++ b/src/ida_mcp/exceptions.py
@@ -15,6 +15,7 @@ import json
 import os
 import re
 import struct
+from collections import Counter
 
 # ToolError is not re-exported from the top-level fastmcp package as of v3.1;
 # if FastMCP reorganizes its internals this import path may need updating.
@@ -193,6 +194,26 @@ def quote_ida_arg(value: str) -> str:
     flags handed to ``idapro.open_database``.
     """
     return f'"{value}"' if " " in value else value
+
+
+def append_output_flag(options: str | None, target_stem: str) -> str:
+    """Return *options* with a ``-o<target_stem>`` flag appended.
+
+    Used for a first-time fat-slice open in :meth:`session.Session.open`:
+    IDA writes the new ``.i64`` at ``target_stem.i64`` instead of the
+    default stem-alongside-input location.  ``options`` is stripped
+    before concatenation so a trailing space in the caller-supplied
+    string does not produce a double space in the final args — harmless
+    for IDA's parser but unsightly in debug logs.  ``None`` and
+    all-whitespace inputs are treated the same as the empty string.
+    """
+    flag = f"-o{quote_ida_arg(target_stem)}"
+    if options is None:
+        return flag
+    stripped = options.strip()
+    if not stripped:
+        return flag
+    return f"{stripped} {flag}"
 
 
 def build_ida_args(
@@ -393,6 +414,32 @@ def detect_fat_slices(file_path: str) -> list[str] | None:
     return slices
 
 
+def reject_fat_arch_on_database(file_path: str, fat_arch: str) -> None:
+    """Raise ``InvalidArgument`` when *fat_arch* is set on an ``.i64``/``.idb`` path.
+
+    Stored databases already pin a specific slice, so ``fat_arch`` on
+    top is either contradictory (the stored analysis belongs to a
+    different slice) or redundant (same slice, the arg does nothing).
+    Both sites that accept user input for ``(file_path, fat_arch)`` —
+    the supervisor's fail-fast path in :func:`check_fat_binary` and
+    :meth:`session.Session.open` for direct callers — share this
+    check, so the message lives here to keep them in sync.
+    """
+    if not fat_arch:
+        return
+    _, ext = os.path.splitext(file_path)
+    if ext.lower() not in PRIMARY_IDB_EXTENSIONS:
+        return
+    raise IDAError(
+        f"fat_arch={fat_arch!r} was specified but {file_path!r} "
+        "is an existing IDA database (.i64/.idb).  The stored "
+        "database already pins a specific slice — remove fat_arch "
+        "to reopen it, or point file_path at the original binary "
+        "to analyze a different slice.",
+        error_type="InvalidArgument",
+    )
+
+
 def check_fat_binary(file_path: str, fat_arch: str, force_new: bool) -> int | None:
     """Validate *fat_arch* for *file_path* and return the slice index.
 
@@ -401,7 +448,8 @@ def check_fat_binary(file_path: str, fat_arch: str, force_new: bool) -> int | No
     fat-slice ``-T`` flag is needed — specifically:
 
     - *file_path* is already an ``.i64`` / ``.idb`` database (stored
-      analysis pins the slice; *fat_arch* is ignored);
+      analysis pins the slice; *fat_arch* **must** be empty in that
+      case — see below);
     - a slice-specific sidecar exists next to the binary and
       ``force_new`` is False (we'll reopen the stored DB below);
     - the file is not a fat Mach-O at all and *fat_arch* is empty
@@ -412,22 +460,37 @@ def check_fat_binary(file_path: str, fat_arch: str, force_new: bool) -> int | No
     - ``AmbiguousFatBinary`` — file is fat but *fat_arch* is empty.
     - ``UnknownFatArch`` — *fat_arch* is not present in the fat header.
     - ``InvalidArgument`` — *fat_arch* was set but the file is **not**
-      a fat Mach-O.  Silently ignoring would let a user mis-select a
-      non-existent slice; making this an error surfaces the mistake
-      before IDA gets a chance to write a confusingly-named sidecar.
+      a fat Mach-O (thin binary, non-Mach-O, ...), **or** *file_path*
+      is an explicit ``.i64``/``.idb`` path.  Silently ignoring either
+      case would let a user mis-select a non-existent slice or expect
+      a re-analysis that is not going to happen; surfacing the error
+      makes the mistake immediate, before IDA writes a confusingly
+      named sidecar.
 
-    The first two errors carry an ``available=`` detail listing the
-    slice names.  The index is the slice's 1-based position in the
-    on-disk fat header, which is the value IDA expects in
-    ``-T"Fat Mach-O file, <N>"`` — the only documented way to pick a
-    fat slice in headless mode.
+    The ambiguous / unknown errors carry an ``available=`` detail
+    listing the slice names.  The index is the slice's 1-based
+    position in the on-disk fat header, which is the value IDA expects
+    in ``-T"Fat Mach-O file, <N>"`` — the only documented way to pick
+    a fat slice in headless mode.
     """
-    if _has_stored_analysis(file_path, force_new, fat_arch):
+    # Resolve symlinks up front so every downstream check sees the real
+    # file — in particular, ``reject_fat_arch_on_database`` keys off the
+    # extension, and a symlink-without-extension pointing at a ``.i64``
+    # would otherwise slip past the fail-fast guard here and only be
+    # caught later inside Session.open.
+    resolved = os.path.realpath(os.path.expanduser(file_path))
+
+    # Explicit database paths already pin a slice.  Accepting fat_arch
+    # on top would either be contradictory (stored analysis belongs to
+    # a different slice) or redundant (same slice, the arg does
+    # nothing).  Either way it is a user error — reject before reading
+    # the file so the caller cannot rely on "silently ignored".
+    reject_fat_arch_on_database(resolved, fat_arch)
+
+    if _has_stored_analysis(resolved, force_new, fat_arch):
         return None
 
-    # detect_fat_slices opens the file directly; realpath+expanduser so
-    # the parser sees the same file as slice_sidecar_stem's dedup key.
-    slices = detect_fat_slices(os.path.realpath(os.path.expanduser(file_path)))
+    slices = detect_fat_slices(resolved)
     if slices is None:
         if fat_arch:
             raise IDAError(
@@ -437,6 +500,30 @@ def check_fat_binary(file_path: str, fat_arch: str, force_new: bool) -> int | No
                 error_type="InvalidArgument",
             )
         return None
+
+    # Defensive: two (cputype, cpusubtype) pairs that both collapse to
+    # the same lipo-style slice name would make ``slices.index(fat_arch)``
+    # ambiguous — we would silently pick the first match and hand IDA an
+    # index the user may not have intended.  No ``lipo``-produced file
+    # hits this case (real universal binaries never repeat an arch, and
+    # _CPU_SUBTYPE_NAMES only refines a small well-known set of pairs),
+    # but malformed / hand-crafted fat headers can.  Reject explicitly
+    # so the ambiguity is never silent.  ``Counter`` preserves insertion
+    # order so ``duplicates`` matches on-disk slice order.
+    duplicates = [name for name, count in Counter(slices).items() if count > 1]
+    if duplicates:
+        raise IDAError(
+            "Fat binary contains multiple slices that resolve to the "
+            f"same architecture name: {', '.join(duplicates)}.  The "
+            "slice cannot be selected unambiguously by fat_arch; "
+            "re-create the binary with lipo(1) to deduplicate, or "
+            "extract the desired slice with ``lipo -thin`` and open "
+            "the thin file directly.\n\n"
+            f"Slices (in on-disk order): {', '.join(slices)}",
+            error_type="DuplicateFatSlice",
+            available=slices,
+            duplicates=duplicates,
+        )
 
     if not fat_arch:
         raise IDAError(
@@ -454,5 +541,7 @@ def check_fat_binary(file_path: str, fat_arch: str, force_new: bool) -> int | No
             available=slices,
         )
     # IDA's ``-T"Fat Mach-O file, <N>"`` uses 1-based indices in
-    # on-disk fat-header order.  detect_fat_slices preserves that order.
+    # on-disk fat-header order.  detect_fat_slices preserves that order,
+    # and the duplicate check above guarantees ``slices.index`` is
+    # unambiguous.
     return slices.index(fat_arch) + 1

--- a/src/ida_mcp/exceptions.py
+++ b/src/ida_mcp/exceptions.py
@@ -385,19 +385,24 @@ def check_fat_binary(file_path: str, fat_arch: str, force_new: bool) -> int | No
     fat-slice ``-T`` flag is needed — specifically:
 
     - *file_path* is already an ``.i64`` / ``.idb`` database (stored
-      analysis pins the slice);
+      analysis pins the slice; *fat_arch* is ignored);
     - a slice-specific sidecar exists next to the binary and
       ``force_new`` is False (we'll reopen the stored DB below);
-    - the file is not a fat Mach-O at all (thin binary, ELF, PE, ...).
+    - the file is not a fat Mach-O at all and *fat_arch* is empty
+      (thin binary, ELF, PE, ...).
 
     Raises :class:`IDAError`:
 
     - ``AmbiguousFatBinary`` — file is fat but *fat_arch* is empty.
     - ``UnknownFatArch`` — *fat_arch* is not present in the fat header.
+    - ``InvalidArgument`` — *fat_arch* was set but the file is **not**
+      a fat Mach-O.  Silently ignoring would let a user mis-select a
+      non-existent slice; making this an error surfaces the mistake
+      before IDA gets a chance to write a confusingly-named sidecar.
 
-    Both errors carry an ``available=`` detail listing the slice names.
-    The index is the slice's 1-based position in the on-disk fat
-    header, which is the value IDA expects in
+    The first two errors carry an ``available=`` detail listing the
+    slice names.  The index is the slice's 1-based position in the
+    on-disk fat header, which is the value IDA expects in
     ``-T"Fat Mach-O file, <N>"`` — the only documented way to pick a
     fat slice in headless mode.
     """
@@ -408,7 +413,14 @@ def check_fat_binary(file_path: str, fat_arch: str, force_new: bool) -> int | No
     # expanded here (Python's open() does not expand ~).
     slices = detect_fat_slices(os.path.abspath(os.path.expanduser(file_path)))
     if slices is None:
-        return None  # Not a fat Mach-O.
+        if fat_arch:
+            raise IDAError(
+                f"fat_arch={fat_arch!r} was specified but {file_path!r} "
+                "is not a Mach-O fat (universal) binary.  Remove "
+                "fat_arch for thin binaries and non-Mach-O files.",
+                error_type="InvalidArgument",
+            )
+        return None
 
     if not fat_arch:
         raise IDAError(

--- a/src/ida_mcp/exceptions.py
+++ b/src/ida_mcp/exceptions.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import struct
 
 # ToolError is not re-exported from the top-level fastmcp package as of v3.1;
 # if FastMCP reorganizes its internals this import path may need updating.
@@ -107,29 +108,66 @@ AMBIGUOUS_PROCESSORS: dict[str, str] = {
 }
 
 
-def check_processor_ambiguity(processor: str, file_path: str, force_new: bool) -> None:
+def slice_sidecar_stem(file_path: str, fat_arch: str = "") -> str:
+    """Return the stored-database stem for *file_path* / *fat_arch*.
+
+    For a raw binary ``foo`` with no *fat_arch* the stem is ``foo`` and
+    IDA's sidecars live at ``foo.i64`` / ``foo.id0`` / ...  When
+    *fat_arch* is set, per-slice sidecars are kept under a slice-suffixed
+    stem (``foo.arm64``) so multiple architectures from the same
+    universal binary can coexist on disk.  When *file_path* is itself
+    an ``.i64`` / ``.idb``, the stem is the path with the extension
+    stripped — *fat_arch* is ignored because the stored DB already pins
+    the slice.
+    """
+    resolved = os.path.abspath(os.path.expanduser(file_path))
+    base, ext = os.path.splitext(resolved)
+    if ext.lower() in PRIMARY_IDB_EXTENSIONS:
+        return base
+    if fat_arch:
+        return f"{resolved}.{fat_arch}"
+    return resolved
+
+
+def _has_stored_analysis(file_path: str, force_new: bool, fat_arch: str = "") -> bool:
+    """True if opening *file_path* will reuse an existing IDA database.
+
+    Either *file_path* itself is an ``.i64``/``.idb``, or (when
+    ``force_new`` is False) there's a sidecar database at the expected
+    stored location that IDA will pick up.  When *fat_arch* is set the
+    check targets the slice-specific sidecar (``foo.arm64.i64``), so
+    different slices of the same fat binary are tracked independently.
+    Callers skip their fail-fast validation in either case since the
+    stored analysis already pins the answer.
+    """
+    _, ext = os.path.splitext(file_path)
+    if ext.lower() in PRIMARY_IDB_EXTENSIONS:
+        return True
+    if force_new:
+        return False
+    stem = slice_sidecar_stem(file_path, fat_arch)
+    return any(os.path.isfile(stem + db_ext) for db_ext in PRIMARY_IDB_EXTENSIONS)
+
+
+def check_processor_ambiguity(
+    processor: str, file_path: str, force_new: bool, fat_arch: str = ""
+) -> None:
     """Raise :class:`IDAError` if *processor* is ambiguous for a raw binary.
 
     Processors like ``arm`` and ``metapc`` support multiple bitness modes.
     For structured formats (ELF, PE, ...) IDA reads the bitness from file
     headers, but for raw binaries it shows an interactive dialog — which
     is suppressed in headless mode, silently picking a (often wrong) default.
+
+    *fat_arch* is plumbed through so the stored-analysis short-circuit
+    finds the slice-specific sidecar (``foo.arm64.i64``) rather than the
+    default one.
     """
     if not processor or ":" in processor:
         return  # Auto-detect or variant already specified.
 
-    # Opening an existing IDA database — bitness is stored in the DB.
-    _, ext = os.path.splitext(file_path)
-    if ext.lower() in PRIMARY_IDB_EXTENSIONS:
+    if _has_stored_analysis(file_path, force_new, fat_arch):
         return
-
-    # If not forcing a fresh analysis, an existing database sidecar means
-    # IDA will reuse stored analysis (including bitness).
-    if not force_new:
-        resolved = os.path.abspath(os.path.expanduser(file_path))
-        for db_ext in PRIMARY_IDB_EXTENSIONS:
-            if os.path.isfile(resolved + db_ext):
-                return
 
     hint = AMBIGUOUS_PROCESSORS.get(processor.lower())
     if hint:
@@ -141,26 +179,63 @@ def check_processor_ambiguity(processor: str, file_path: str, force_new: bool) -
 # ---------------------------------------------------------------------------
 
 
+def quote_ida_arg(value: str) -> str:
+    """Double-quote *value* if it contains whitespace.
+
+    IDA's C-level arg parser understands ``"double quoted"`` values but
+    not POSIX single quotes; paths / loader names with spaces must be
+    wrapped before being concatenated into the ``-T`` / ``-o`` / ...
+    flags handed to ``idapro.open_database``.
+    """
+    return f'"{value}"' if " " in value else value
+
+
 def build_ida_args(
     *,
     processor: str = "",
     loader: str = "",
     base_address: str = "",
+    fat_slice_index: int | None = None,
     options: str = "",
 ) -> str | None:
     """Build an IDA command-line args string from structured parameters.
 
     Returns ``None`` when no arguments are needed.  Raises :class:`IDAError`
-    on invalid *base_address* or when *options* duplicates a flag that is
-    already provided by a structured parameter.
+    on invalid *base_address*, on a *loader* / *fat_slice_index* conflict,
+    or when *options* duplicates a flag that is already provided by a
+    structured parameter.
+
+    When *fat_slice_index* is set it overrides *loader*: IDA's ``-T``
+    flag is emitted as ``-T"Fat Mach-O file, <index>"``, which is the
+    only documented way to pick a specific slice of a Mach-O universal
+    binary in headless mode.  The slice index is 1-based, in the order
+    the slices appear in the on-disk fat header.  *loader* and
+    *fat_slice_index* both use ``-T`` under the hood, so callers must
+    pick one — setting both raises ``InvalidArgument``.
     """
+    if fat_slice_index is not None and loader:
+        raise IDAError(
+            "loader and fat_arch cannot both be specified — both map to "
+            "IDA's -T flag, and fat_arch selects the Fat Mach-O slice "
+            "loader implicitly.",
+            error_type="InvalidArgument",
+        )
+
+    # When a fat slice is requested, the ``-T`` value is a synthetic
+    # loader name built from the slice index.  Otherwise use the
+    # caller-provided loader string (possibly empty).
+    if fat_slice_index is not None:
+        effective_loader = f"Fat Mach-O file, {fat_slice_index}"
+    else:
+        effective_loader = loader
+
     # Reject options that duplicate a structured parameter already in use.
     # Match flags only at the start of the string or after whitespace to
     # avoid false positives on longer flags (e.g. "-p" inside "--prefer").
     if options:
         for flag, value, param_name in (
             ("-p", processor, "processor"),
-            ("-T", loader, "loader"),
+            ("-T", effective_loader, "loader"),
             ("-b", base_address, "base_address"),
         ):
             if value and re.search(rf"(?:^|\s){re.escape(flag)}", options):
@@ -173,11 +248,8 @@ def build_ida_args(
     args_parts: list[str] = []
     if processor:
         args_parts.append(f"-p{processor}")
-    if loader:
-        # Values containing spaces must be quoted so IDA's C-level arg parser
-        # doesn't split them into separate positional arguments.
-        val = f'"{loader}"' if " " in loader else loader
-        args_parts.append(f"-T{val}")
+    if effective_loader:
+        args_parts.append(f"-T{quote_ida_arg(effective_loader)}")
     if base_address:
         try:
             addr = int(base_address, 0)
@@ -197,3 +269,162 @@ def build_ida_args(
     if options:
         args_parts.append(options)
     return " ".join(args_parts) or None
+
+
+# ---------------------------------------------------------------------------
+# Mach-O fat binary detection (idalib-safe)
+# ---------------------------------------------------------------------------
+
+# Big-endian magics that appear on disk for Mach-O universal binaries.
+# FAT_MAGIC uses 32-bit offsets; FAT_MAGIC_64 uses 64-bit offsets.  The
+# "swapped" forms (BEBAFECA / BFBAFECA) are only produced on byte-swapping
+# hosts and never appear in on-disk files.
+_FAT_MAGIC = 0xCAFEBABE
+_FAT_MAGIC_64 = 0xCAFEBABF
+
+# Cap the number of slices we'll accept in a fat header.  Real fat
+# binaries almost never exceed a handful of architectures; a large
+# nfat_arch is a strong signal the file is a Java ``.class`` (which
+# shares the CAFEBABE magic but stores a version number next).
+_MAX_FAT_SLICES = 32
+
+# Mach-O cputype constants.  The CPU_ARCH_ABI64 bit (0x01000000) flags
+# 64-bit variants, CPU_ARCH_ABI64_32 (0x02000000) flags ILP32 on 64-bit
+# (arm64_32).  See /usr/include/mach/machine.h.
+_CPU_TYPE_NAMES: dict[int, str] = {
+    7: "i386",
+    0x01000007: "x86_64",
+    12: "arm",
+    0x0100000C: "arm64",
+    0x0200000C: "arm64_32",
+    18: "ppc",
+    0x01000012: "ppc64",
+}
+
+# XNU's CPU_SUBTYPE_MASK (0xFF000000) marks the feature-flag bits; we
+# AND with its inverse to keep just the architecture subtype id before
+# comparison.
+_CPU_SUBTYPE_MASK = 0x00FFFFFF
+
+# Well-known cpusubtype refinements we want to surface as distinct names,
+# matching lipo(1)'s output.  Key is (cputype, cpusubtype & mask).
+_CPU_SUBTYPE_NAMES: dict[tuple[int, int], str] = {
+    (0x01000007, 8): "x86_64h",  # CPU_SUBTYPE_X86_64_H (Haswell)
+    (0x0100000C, 2): "arm64e",  # CPU_SUBTYPE_ARM64E
+    (12, 9): "armv7",  # CPU_SUBTYPE_ARM_V7
+    (12, 11): "armv7s",  # CPU_SUBTYPE_ARM_V7S
+    (12, 12): "armv7k",  # CPU_SUBTYPE_ARM_V7K
+    (12, 6): "armv6",  # CPU_SUBTYPE_ARM_V6
+}
+
+
+def _fat_slice_name(cputype: int, cpusubtype: int) -> str | None:
+    """Resolve a (cputype, cpusubtype) pair to a human-readable slice name.
+
+    Returns ``None`` when the cputype is not a recognised Mach-O arch —
+    the caller treats that as "this is not a fat Mach-O" and bails out.
+    This is the Java ``.class`` defence: unknown cputypes fall through
+    rather than being wrapped in a synthetic name.
+    """
+    if cputype not in _CPU_TYPE_NAMES:
+        return None
+    sub = cpusubtype & _CPU_SUBTYPE_MASK
+    return _CPU_SUBTYPE_NAMES.get((cputype, sub)) or _CPU_TYPE_NAMES[cputype]
+
+
+def detect_fat_slices(file_path: str) -> list[str] | None:
+    """Return the list of architecture slices in a Mach-O fat binary.
+
+    Parses the on-disk FAT_MAGIC / FAT_MAGIC_64 header and resolves each
+    entry's ``cputype``/``cpusubtype`` to a ``lipo``-style name.
+
+    Returns ``None`` when *file_path* is not a fat Mach-O — missing
+    file, too short, wrong magic, absurd ``nfat_arch``, or any entry
+    whose cputype is not a recognised Mach-O architecture.  This is a
+    deliberately conservative detector: Java ``.class`` files share
+    the ``CAFEBABE`` magic, and we must not misclassify them.
+    """
+    try:
+        with open(file_path, "rb") as f:
+            header = f.read(8)
+            if len(header) < 8:
+                return None
+            magic, nfat_arch = struct.unpack(">II", header)
+            if magic == _FAT_MAGIC:
+                fmt = ">IIIII"  # struct fat_arch: cputype, cpusubtype, offset, size, align
+            elif magic == _FAT_MAGIC_64:
+                fmt = ">IIQQII"  # struct fat_arch_64: + reserved; 64-bit offset/size
+            else:
+                return None
+            if nfat_arch == 0 or nfat_arch > _MAX_FAT_SLICES:
+                return None
+            want = struct.calcsize(fmt) * nfat_arch
+            entries_raw = f.read(want)
+            if len(entries_raw) < want:
+                return None
+    except OSError:
+        return None
+
+    slices: list[str] = []
+    for cputype, cpusubtype, *_ in struct.iter_unpack(fmt, entries_raw):
+        name = _fat_slice_name(cputype, cpusubtype)
+        if name is None:
+            # Unknown cputype — treat the whole file as not-fat rather
+            # than returning a half-parsed list.  This is the Java
+            # ``.class`` defence.
+            return None
+        slices.append(name)
+    return slices
+
+
+def check_fat_binary(file_path: str, fat_arch: str, force_new: bool) -> int | None:
+    """Validate *fat_arch* for *file_path* and return the slice index.
+
+    Returns the **1-based** slice index suitable for passing to
+    :func:`build_ida_args` as ``fat_slice_index``, or ``None`` when no
+    fat-slice ``-T`` flag is needed — specifically:
+
+    - *file_path* is already an ``.i64`` / ``.idb`` database (stored
+      analysis pins the slice);
+    - a slice-specific sidecar exists next to the binary and
+      ``force_new`` is False (we'll reopen the stored DB below);
+    - the file is not a fat Mach-O at all (thin binary, ELF, PE, ...).
+
+    Raises :class:`IDAError`:
+
+    - ``AmbiguousFatBinary`` — file is fat but *fat_arch* is empty.
+    - ``UnknownFatArch`` — *fat_arch* is not present in the fat header.
+
+    Both errors carry an ``available=`` detail listing the slice names.
+    The index is the slice's 1-based position in the on-disk fat
+    header, which is the value IDA expects in
+    ``-T"Fat Mach-O file, <N>"`` — the only documented way to pick a
+    fat slice in headless mode.
+    """
+    if _has_stored_analysis(file_path, force_new, fat_arch):
+        return None
+
+    # detect_fat_slices opens the file directly, so tilde-paths must be
+    # expanded here (Python's open() does not expand ~).
+    slices = detect_fat_slices(os.path.abspath(os.path.expanduser(file_path)))
+    if slices is None:
+        return None  # Not a fat Mach-O.
+
+    if not fat_arch:
+        raise IDAError(
+            "File is a Mach-O fat binary with multiple architecture "
+            "slices.  Pass fat_arch= to pick one.\n\n"
+            f"Available: {', '.join(slices)}",
+            error_type="AmbiguousFatBinary",
+            available=slices,
+        )
+    if fat_arch not in slices:
+        raise IDAError(
+            f"fat_arch={fat_arch!r} is not present in this fat binary.\n\n"
+            f"Available: {', '.join(slices)}",
+            error_type="UnknownFatArch",
+            available=slices,
+        )
+    # IDA's ``-T"Fat Mach-O file, <N>"`` uses 1-based indices in
+    # on-disk fat-header order.  detect_fat_slices preserves that order.
+    return slices.index(fat_arch) + 1

--- a/src/ida_mcp/exceptions.py
+++ b/src/ida_mcp/exceptions.py
@@ -414,6 +414,20 @@ def detect_fat_slices(file_path: str) -> list[str] | None:
     return slices
 
 
+def _is_primary_idb_path(file_path: str) -> bool:
+    """True if *file_path* resolves to an ``.i64``/``.idb`` database path.
+
+    Resolves symlinks and ``~`` internally so a link-without-extension
+    pointing at a stored database (``./shortcut`` → ``real.i64``) is
+    classified the same as a direct path.  Callers that need the
+    resolved path for other work should call :func:`os.path.realpath`
+    themselves — this helper is a pure predicate.
+    """
+    resolved = os.path.realpath(os.path.expanduser(file_path))
+    _, ext = os.path.splitext(resolved)
+    return ext.lower() in PRIMARY_IDB_EXTENSIONS
+
+
 def reject_fat_arch_on_database(file_path: str, fat_arch: str) -> None:
     """Raise ``InvalidArgument`` when *fat_arch* is set on an ``.i64``/``.idb`` path.
 
@@ -424,11 +438,16 @@ def reject_fat_arch_on_database(file_path: str, fat_arch: str) -> None:
     the supervisor's fail-fast path in :func:`check_fat_binary` and
     :meth:`session.Session.open` for direct callers — share this
     check, so the message lives here to keep them in sync.
+
+    *file_path* is resolved internally (see :func:`_is_primary_idb_path`)
+    so a symlink without a ``.i64`` extension pointing at a stored
+    database is still caught.  The **original** path is shown in the
+    error message so the user sees what they typed, not the resolved
+    path under the hood — matching the rest of :func:`check_fat_binary`.
     """
     if not fat_arch:
         return
-    _, ext = os.path.splitext(file_path)
-    if ext.lower() not in PRIMARY_IDB_EXTENSIONS:
+    if not _is_primary_idb_path(file_path):
         return
     raise IDAError(
         f"fat_arch={fat_arch!r} was specified but {file_path!r} "
@@ -436,6 +455,43 @@ def reject_fat_arch_on_database(file_path: str, fat_arch: str) -> None:
         "database already pins a specific slice — remove fat_arch "
         "to reopen it, or point file_path at the original binary "
         "to analyze a different slice.",
+        error_type="InvalidArgument",
+    )
+
+
+def reject_force_new_on_database(file_path: str, force_new: bool) -> None:
+    """Raise ``InvalidArgument`` when *force_new* is set on an ``.i64``/``.idb`` path.
+
+    ``force_new`` means *"discard the stored analysis and re-analyze
+    from the original binary"*.  That only makes sense when *file_path*
+    names the binary — if it names the database itself (``.i64`` /
+    ``.idb``), :meth:`session.Session.open` would strip the extension,
+    delete the database files, and then try to open the (possibly
+    missing) binary at the stem path.  When the binary is absent, the
+    stored analysis is destroyed with nothing to re-analyze from and no
+    recovery path.  Even when the binary *is* present, passing the
+    database path with ``force_new=True`` is confusing — the path
+    refers to the thing being destroyed rather than the thing being
+    opened.
+
+    Fail fast at every entry point (supervisor, worker tool,
+    :meth:`Session.open`) so the user cannot destroy their stored
+    analysis by pointing ``file_path`` at the wrong thing.  *file_path*
+    is resolved internally (see :func:`_is_primary_idb_path`) so a
+    symlink-without-extension pointing at an ``.i64`` is also rejected.
+    """
+    if not force_new:
+        return
+    if not _is_primary_idb_path(file_path):
+        return
+    raise IDAError(
+        f"force_new=True cannot be combined with an existing IDA "
+        f"database path ({file_path!r}).  force_new deletes the "
+        "stored analysis and re-analyzes from the original binary, "
+        "so it needs the binary path — not the database path — as "
+        "file_path.  Pass the original binary (raw file without "
+        "the .i64/.idb extension) instead, or call with "
+        "force_new=False to reuse the existing database.",
         error_type="InvalidArgument",
     )
 
@@ -461,11 +517,15 @@ def check_fat_binary(file_path: str, fat_arch: str, force_new: bool) -> int | No
     - ``UnknownFatArch`` — *fat_arch* is not present in the fat header.
     - ``InvalidArgument`` — *fat_arch* was set but the file is **not**
       a fat Mach-O (thin binary, non-Mach-O, ...), **or** *file_path*
-      is an explicit ``.i64``/``.idb`` path.  Silently ignoring either
-      case would let a user mis-select a non-existent slice or expect
-      a re-analysis that is not going to happen; surfacing the error
-      makes the mistake immediate, before IDA writes a confusingly
-      named sidecar.
+      is an explicit ``.i64``/``.idb`` path, **or** *force_new* is
+      set on an ``.i64``/``.idb`` path (which would delete the stored
+      analysis before :meth:`Session.open` could find the binary to
+      re-analyze).  Silently ignoring any of these would let a user
+      mis-select a non-existent slice, expect a re-analysis that is
+      not going to happen, or destroy their stored analysis with no
+      recovery path; surfacing the error makes the mistake immediate,
+      before IDA writes a confusingly named sidecar or we delete the
+      wrong files.
 
     The ambiguous / unknown errors carry an ``available=`` detail
     listing the slice names.  The index is the slice's 1-based
@@ -473,19 +533,19 @@ def check_fat_binary(file_path: str, fat_arch: str, force_new: bool) -> int | No
     in ``-T"Fat Mach-O file, <N>"`` — the only documented way to pick
     a fat slice in headless mode.
     """
-    # Resolve symlinks up front so every downstream check sees the real
-    # file — in particular, ``reject_fat_arch_on_database`` keys off the
-    # extension, and a symlink-without-extension pointing at a ``.i64``
-    # would otherwise slip past the fail-fast guard here and only be
-    # caught later inside Session.open.
-    resolved = os.path.realpath(os.path.expanduser(file_path))
+    # ``reject_fat_arch_on_database`` / ``reject_force_new_on_database``
+    # resolve symlinks internally so a symlink-without-extension
+    # pointing at a ``.i64`` is caught the same as a direct path.  Both
+    # are no-ops on thin/raw files, so calling them unconditionally is
+    # safe.  Ordering: reject force_new+database first so the user sees
+    # the most direct "wrong path type" error before we start parsing
+    # fat headers.
+    reject_force_new_on_database(file_path, force_new)
+    reject_fat_arch_on_database(file_path, fat_arch)
 
-    # Explicit database paths already pin a slice.  Accepting fat_arch
-    # on top would either be contradictory (stored analysis belongs to
-    # a different slice) or redundant (same slice, the arg does
-    # nothing).  Either way it is a user error — reject before reading
-    # the file so the caller cannot rely on "silently ignored".
-    reject_fat_arch_on_database(resolved, fat_arch)
+    # The rest of the check needs a resolved path to read the file and
+    # to key the slice-specific sidecar lookup off the real name.
+    resolved = os.path.realpath(os.path.expanduser(file_path))
 
     if _has_stored_analysis(resolved, force_new, fat_arch):
         return None

--- a/src/ida_mcp/helpers.py
+++ b/src/ida_mcp/helpers.py
@@ -164,8 +164,8 @@ def check_cancelled() -> None:
 def is_cancelled() -> bool:
     """Return ``True`` if the IDA cancellation flag is set.
 
-    Use this in loops that simply need to ``break`` on cancellation
-    rather than propagate an exception.
+    Use this in loops that need to ``break`` on cancellation rather
+    than propagate an exception.
     """
     return ida_kernwin.user_cancelled()
 

--- a/src/ida_mcp/sandbox.py
+++ b/src/ida_mcp/sandbox.py
@@ -74,6 +74,29 @@ def _forbidden_attr_message(name: str) -> str:
     return f'"{name}" is an invalid attribute name'
 
 
+def _rejected_stmt_placeholder(node: ast.stmt) -> ast.stmt:
+    """Return a safe ``ast.Pass`` placeholder copied onto *node*'s location.
+
+    Defense-in-depth for visit methods that reject a statement via
+    :meth:`RestrictingNodeTransformer.error`: upstream RestrictedPython
+    accumulates errors and raises ``SyntaxError`` at the end of
+    ``compile_restricted``, so returning the original (unvisited)
+    rejected node is safe *today* because the bytecode is never
+    emitted.  But if that error-collection contract were ever relaxed,
+    returning the original AugAssign/Attribute node would leave the
+    rejected construct in the tree and compile it to real bytecode.
+
+    Replacing the rejected statement with a ``Pass`` closes that door
+    up front: even if upstream's error handling becomes non-fatal, the
+    worst that can happen is a no-op where the rejected statement used
+    to live.  Locations are copied so any later error messages still
+    point at the user's original line/column.
+    """
+    placeholder = ast.Pass()
+    copy_locations(placeholder, node)
+    return placeholder
+
+
 def _is_simple_attr_chain(node: ast.expr) -> bool:
     """True if *node* is a plain ``Name`` or a chain of ``Attribute`` → ``Name``.
 
@@ -226,7 +249,7 @@ class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
             target = node.target
             if _is_forbidden_attr(target.attr):
                 self.error(node, _forbidden_attr_message(target.attr))
-                return node
+                return _rejected_stmt_placeholder(node)
 
             if not _is_simple_attr_chain(target.value):
                 self.error(
@@ -241,7 +264,7 @@ class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
                     "computation.  Assign to a temporary first: "
                     "tmp = ...; tmp.attr += value",
                 )
-                return node
+                return _rejected_stmt_placeholder(node)
 
             op_str = IOPERATOR_TO_STR[type(node.op)]
 

--- a/src/ida_mcp/sandbox.py
+++ b/src/ida_mcp/sandbox.py
@@ -12,19 +12,59 @@ that allows async/await.  Used by the ``execute`` meta-tool in
 from __future__ import annotations
 
 import ast
+import copy
 import operator
 from collections.abc import Callable
 from typing import Any
 
 from RestrictedPython import compile_restricted, safe_builtins
-from RestrictedPython.Guards import guarded_unpack_sequence, safer_getattr
-from RestrictedPython.transformer import RestrictingNodeTransformer
+from RestrictedPython.Guards import guarded_unpack_sequence
+from RestrictedPython.PrintCollector import PrintCollector
+from RestrictedPython.transformer import (
+    INSPECT_ATTRIBUTES,
+    IOPERATOR_TO_STR,
+    RestrictingNodeTransformer,
+    copy_locations,
+)
 
 # ---------------------------------------------------------------------------
 # Custom policy — allow async/await on top of standard restrictions
 # ---------------------------------------------------------------------------
 
 _WRAPPER_NAME = "sandboxmain"
+
+
+def _is_forbidden_attr(name: str) -> bool:
+    """True if *name* must be blocked as an attribute name in sandboxed code.
+
+    The sandbox policy is more permissive than RestrictedPython's default:
+    single-underscore "private" names (``_foo``) are allowed because they
+    are a universal Python convention on user-defined classes and carry
+    no capability beyond what the public API already exposes.  What
+    remains blocked:
+
+    - **Dunder names** (``__foo``, ``__foo__``): these expose CPython
+      internals — ``__class__``, ``__bases__``, ``__mro__``,
+      ``__subclasses__``, ``__globals__``, ``__code__``, ``__builtins__``,
+      ``__dict__`` — any one of which lets sandbox code walk out of the
+      sandbox to arbitrary objects and thereby bypass every other guard.
+    - **``__roles__`` suffix**: a Zope-specific security marker; kept for
+      parity with RestrictedPython's default policy.
+    - **``INSPECT_ATTRIBUTES``**: frame / code / coroutine / generator
+      introspection names (``f_globals``, ``cr_frame``, ``gi_code``, ...)
+      that do *not* start with ``_`` but leak live frames and bytecode.
+      Must be blocked explicitly.
+    """
+    if name.startswith("__"):
+        return True
+    if name.endswith("__roles__"):
+        return True
+    return name in INSPECT_ATTRIBUTES
+
+
+def _forbidden_attr_message(name: str) -> str:
+    """Human-readable reason for blocking *name* as an attribute."""
+    return f'"{name}" is an invalid attribute name'
 
 
 class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
@@ -34,6 +74,10 @@ class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
     by the upstream transformer.  This subclass mirrors the handling of their
     synchronous equivalents so that ``await call_tool(...)`` and
     ``asyncio.gather(...)`` work inside execute blocks.
+
+    It also relaxes the upstream attribute-name policy: single-underscore
+    "private" attributes (``self._name``) are permitted — see
+    :func:`_is_forbidden_attr`.  Dunder access remains blocked.
     """
 
     def visit_AsyncFunctionDef(self, node):
@@ -48,7 +92,13 @@ class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
         return self.node_contents_visit(node)
 
     def visit_AsyncFor(self, node):
-        return self.guard_iter(node)
+        # Do not delegate to ``guard_iter``: it would wrap the iterable in
+        # ``_getiter_(expr)`` (bound to the sync builtin ``iter``), which
+        # fails on async iterators because they expose ``__aiter__`` /
+        # ``__anext__`` rather than ``__iter__``.  The sandbox's ``_getiter_``
+        # is already a pass-through for sync iteration, so skipping the wrap
+        # here loses no real protection.
+        return self.node_contents_visit(node)
 
     def visit_AsyncWith(self, node):
         node = self.node_contents_visit(node)
@@ -58,6 +108,126 @@ class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
                 item.optional_vars = tmp_target
                 node.body.insert(0, unpack)
         return node
+
+    def visit_Attribute(self, node):
+        """Rewrite attribute access and block dangerous names.
+
+        Replaces the upstream ``visit_Attribute`` wholesale because the
+        parent rejects every name that starts with ``_`` — even single-
+        underscore conventional private names.  This override keeps the
+        same AST rewrite (``a.b`` → ``_getattr_(a, "b")``,
+        ``a.b = c`` → ``_write_(a).b = c``) but consults
+        :func:`_is_forbidden_attr` for the name check, so ``self._x`` is
+        legal while ``obj.__class__`` is still rejected at compile time.
+        """
+        if _is_forbidden_attr(node.attr):
+            self.error(node, _forbidden_attr_message(node.attr))
+
+        if isinstance(node.ctx, ast.Load):
+            node = self.node_contents_visit(node)
+            new_node = ast.Call(
+                func=ast.Name("_getattr_", ast.Load()),
+                args=[node.value, ast.Constant(node.attr)],
+                keywords=[],
+            )
+            copy_locations(new_node, node)
+            return new_node
+
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            node = self.node_contents_visit(node)
+            new_value = ast.Call(
+                func=ast.Name("_write_", ast.Load()),
+                args=[node.value],
+                keywords=[],
+            )
+            copy_locations(new_value, node.value)
+            node.value = new_value
+            return node
+
+        # ast.Attribute only has Load, Store, Del contexts — anything else
+        # is a CPython-internal bug we want to surface loudly.
+        raise NotImplementedError(f"Unknown ctx type: {type(node.ctx)}")
+
+    def visit_AugAssign(self, node):
+        """Allow augmented assignment on attribute targets.
+
+        The upstream policy rejects ``obj.x += y`` outright.  We rewrite
+        it into an ``Assign`` node that looks like
+        ``_write_(obj).x = _inplacevar_("+=", _getattr_(obj, "x"), y)``
+        — the same shape the transformer would produce for a plain
+        ``obj.x`` read on one side and ``obj.x = ...`` write on the
+        other — and return it directly.
+
+        We cannot just return a raw ``Attribute`` AugAssign and let
+        ``self.visit(...)`` walk it: re-visiting the freshly-built
+        ``_inplacevar_`` ``Name`` would trip ``check_name``, which
+        rejects underscore-prefixed variable names.  So we visit only
+        the user-supplied subexpressions (``node.target.value`` and
+        ``node.value``) and hand-assemble the guard-wrapped nodes
+        around them.
+
+        Subscript targets (``obj[k] += v``) are still forwarded to the
+        parent, which rejects them.  Name targets also defer to the
+        parent, which rewrites them via ``_inplacevar_`` identically.
+
+        Evaluation order: CPython evaluates ``obj`` once for
+        ``obj.x += y`` (DUP_TOP on the object); this rewrite evaluates
+        ``obj`` twice.  For simple names — the common case — it's
+        observationally identical.  Side-effectful ``obj`` expressions
+        (``f().x += 1``) diverge; the sandbox does not promise
+        CPython-identical semantics there.
+        """
+        if isinstance(node.target, ast.Attribute):
+            target = node.target
+            if _is_forbidden_attr(target.attr):
+                self.error(node, _forbidden_attr_message(target.attr))
+                return node
+
+            op_str = IOPERATOR_TO_STR[type(node.op)]
+
+            # Visit the user-supplied subexpressions first so any guards
+            # they need (nested attribute reads, subscripts, ...) are
+            # applied.  Everything below builds guard-wrapped nodes by
+            # hand and must NOT be re-visited — ``_getattr_``, ``_write_``,
+            # and ``_inplacevar_`` names would fail ``check_name``.
+            obj_load = self.visit(target.value)
+            rhs = self.visit(node.value)
+
+            # Load side: ``_getattr_(obj, "x")``.
+            load_call = ast.Call(
+                func=ast.Name("_getattr_", ast.Load()),
+                args=[obj_load, ast.Constant(target.attr)],
+                keywords=[],
+            )
+
+            # Store side: ``_write_(obj).x = ...``.  Deep-copy ``obj_load``
+            # so the Load and Store expressions own independent subtrees;
+            # sharing would confuse the compiler's AST location tracking
+            # and risks double-processing if the node is ever walked again.
+            store_obj_wrapped = ast.Call(
+                func=ast.Name("_write_", ast.Load()),
+                args=[copy.deepcopy(obj_load)],
+                keywords=[],
+            )
+            store_target = ast.Attribute(
+                value=store_obj_wrapped,
+                attr=target.attr,
+                ctx=ast.Store(),
+            )
+
+            new_node = ast.Assign(
+                targets=[store_target],
+                value=ast.Call(
+                    func=ast.Name("_inplacevar_", ast.Load()),
+                    args=[ast.Constant(op_str), load_call, rhs],
+                    keywords=[],
+                ),
+            )
+            copy_locations(new_node, node)
+            ast.fix_missing_locations(new_node)
+            return new_node
+
+        return super().visit_AugAssign(node)
 
 
 # ---------------------------------------------------------------------------
@@ -119,10 +289,58 @@ def _inplacevar(op: str, x: Any, y: Any) -> Any:
     return fn(x, y)
 
 
+def _apply(f: Any, *args: Any, **kwargs: Any) -> Any:
+    """Guard for calls that use ``*args`` or ``**kwargs`` unpacking.
+
+    RestrictedPython's transformer rewrites ``f(*args, **kwargs)`` into
+    ``_apply_(f, *args, **kwargs)``.  A pass-through is safe here: the AST
+    guards already wrap attribute/item access used to obtain ``f`` and to
+    build the arg/kwarg iterables, so no additional wrapping is required.
+    """
+    return f(*args, **kwargs)
+
+
+_NO_DEFAULT = object()
+
+
+def _sandbox_getattr(
+    obj: Any,
+    name: str,
+    default: Any = _NO_DEFAULT,
+    getattr: Callable[..., Any] = getattr,
+) -> Any:
+    """``getattr`` variant matching the sandbox's relaxed name policy.
+
+    Replaces :func:`RestrictedPython.Guards.safer_getattr` so that the
+    runtime guard agrees with the compile-time check in
+    :meth:`_AsyncRestrictingNodeTransformer.visit_Attribute`: dunder
+    names, ``INSPECT_ATTRIBUTES``, and ``str.format`` / ``str.format_map``
+    remain blocked, while single-underscore "private" names are allowed.
+
+    Bound as ``_getattr_`` in the sandbox globals, so it is also invoked
+    by the AST rewrite of every ``obj.attr`` read.  The builtin
+    ``getattr`` alias in the sandbox builtins uses this same function.
+    """
+    if type(name) is not str:
+        raise TypeError("type(name) must be str")
+    if name in ("format", "format_map") and (
+        isinstance(obj, str) or (isinstance(obj, type) and issubclass(obj, str))
+    ):
+        # CVE-class: str.format lets you pull attributes off any
+        # argument, which would reach __class__ and friends regardless
+        # of the AST guard.  See http://lucumr.pocoo.org/2016/12/29/careful-with-str-format/.
+        raise NotImplementedError("Using the format*() methods of `str` is not safe")
+    if _is_forbidden_attr(name):
+        raise AttributeError(_forbidden_attr_message(name))
+    if default is _NO_DEFAULT:
+        return getattr(obj, name)
+    return getattr(obj, name, default)
+
+
 def _safe_hasattr(obj: Any, name: str) -> bool:
-    """``hasattr`` that respects RestrictedPython's attribute guards."""
+    """``hasattr`` that respects the sandbox's attribute-name policy."""
     try:
-        safer_getattr(obj, name)
+        _sandbox_getattr(obj, name)
         return True
     except AttributeError:
         return False
@@ -160,16 +378,28 @@ _SANDBOX_BUILTINS: dict[str, Any] = {
     "bin": bin,
     "hex": hex,
     "oct": oct,
-    # Introspection — getattr/hasattr must go through safer_getattr to block
-    # dunder access; raw builtins would bypass the _getattr_ AST guard.
+    # Introspection — getattr/hasattr must go through the sandbox's
+    # name-policy guard so dunder / frame-introspection attributes stay
+    # out of reach even when user code bypasses attribute syntax.
     "type": type,
     "isinstance": isinstance,
     "hasattr": _safe_hasattr,
-    "getattr": safer_getattr,
+    "getattr": _sandbox_getattr,
     # Formatting
     "format": format,
-    "print": print,
     "super": super,
+    # Class-definition helpers — required to use ``@classmethod`` /
+    # ``@staticmethod`` / ``@property`` decorators inside user classes.
+    # All three are pure descriptor wrappers and add no capability beyond
+    # what ``class``/``def`` already permit.
+    "classmethod": classmethod,
+    "staticmethod": staticmethod,
+    "property": property,
+    # Note: ``print`` is intentionally not in builtins.  RestrictedPython's
+    # transformer rewrites every ``print(...)`` call site to
+    # ``_print._call_print(...)`` where ``_print`` is a ``PrintCollector``
+    # instance injected at the top of the wrapper function.  Any ``print``
+    # entry here would be dead code.  See ``_print_`` in ``_make_globals``.
 }
 
 
@@ -181,8 +411,15 @@ def _make_globals(
     """Build the restricted globals dict for ``exec()``."""
     glb: dict[str, Any] = {
         "__builtins__": _SANDBOX_BUILTINS,
+        # CPython's class-creation bytecode reads ``__name__`` from the
+        # enclosing namespace to set ``__module__`` on new classes.  Without
+        # this entry, ``class C: ...`` raises ``NameError: name '__name__'
+        # is not defined``.  Safe to expose: user code cannot read bare
+        # ``__name__`` because the AST transformer rejects dunder names at
+        # compile time.
+        "__name__": "sandbox",
         "_getiter_": iter,
-        "_getattr_": safer_getattr,
+        "_getattr_": _sandbox_getattr,
         "_getitem_": operator.getitem,
         "_iter_unpack_sequence_": guarded_unpack_sequence,
         "_unpack_sequence_": guarded_unpack_sequence,
@@ -195,6 +432,19 @@ def _make_globals(
         # mutation cannot affect server internals.
         "_write_": lambda obj: obj,
         "_inplacevar_": _inplacevar,
+        "_apply_": _apply,
+        # ``_print_`` is the factory the transformer calls when user code
+        # uses ``print(...)``.  Rewritten call sites become
+        # ``_print._call_print(...)`` on an instance of this class, and the
+        # ``printed`` magic name reads back the collected output.
+        "_print_": PrintCollector,
+        # ``__metaclass__`` is referenced by every ``class`` statement in
+        # restricted code: the transformer rewrites ``class C(...)`` to
+        # ``class C(..., metaclass=__metaclass__)``.  Plain ``type`` yields
+        # ordinary classes — attribute access on instances still goes
+        # through ``_sandbox_getattr`` via the ``_getattr_`` AST guard, so
+        # no custom metaclass is needed.
+        "__metaclass__": type,
     }
     if inputs:
         glb.update(inputs)

--- a/src/ida_mcp/sandbox.py
+++ b/src/ida_mcp/sandbox.py
@@ -29,6 +29,13 @@ from RestrictedPython.transformer import (
 
 # ---------------------------------------------------------------------------
 # Custom policy — allow async/await on top of standard restrictions
+#
+# Audited against RestrictedPython 8.1.  ``visit_Attribute`` and
+# ``visit_AugAssign`` below replace the upstream implementations wholesale
+# (no ``super()`` call), and the imports of ``INSPECT_ATTRIBUTES`` /
+# ``IOPERATOR_TO_STR`` reach into non-public transformer internals — on a
+# RestrictedPython upgrade, diff the new upstream against these copies and
+# re-port any security tightening.
 # ---------------------------------------------------------------------------
 
 _WRAPPER_NAME = "sandboxmain"
@@ -171,16 +178,31 @@ class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
         parent, which rewrites them via ``_inplacevar_`` identically.
 
         Evaluation order: CPython evaluates ``obj`` once for
-        ``obj.x += y`` (DUP_TOP on the object); this rewrite evaluates
-        ``obj`` twice.  For simple names — the common case — it's
-        observationally identical.  Side-effectful ``obj`` expressions
-        (``f().x += 1``) diverge; the sandbox does not promise
-        CPython-identical semantics there.
+        ``obj.x += y`` (DUP_TOP on the object); this rewrite would
+        evaluate ``obj`` twice.  For a simple ``Name`` / ``Attribute``
+        chain (``self.x += 1``, ``self.counter.n += 1``) that's
+        observationally identical — the lookups are idempotent.  For a
+        ``Call`` on the chain (``f().x += 1``, ``obj.method().count += 1``)
+        the two evaluations would produce independent objects and the
+        store would vanish.  Rather than silently diverge from CPython,
+        we reject those cases at compile time and force the user to
+        split the statement: ``tmp = f(); tmp.x += 1``.
         """
         if isinstance(node.target, ast.Attribute):
             target = node.target
             if _is_forbidden_attr(target.attr):
                 self.error(node, _forbidden_attr_message(target.attr))
+                return node
+
+            if any(isinstance(sub, ast.Call) for sub in ast.walk(target.value)):
+                self.error(
+                    node,
+                    "Augmented assignment on an attribute whose object "
+                    "expression contains a function call is not "
+                    "supported in the sandbox (the object would be "
+                    "evaluated twice).  Assign to a temporary first: "
+                    "tmp = ...; tmp.attr += value",
+                )
                 return node
 
             op_str = IOPERATOR_TO_STR[type(node.op)]
@@ -293,11 +315,64 @@ def _apply(f: Any, *args: Any, **kwargs: Any) -> Any:
     """Guard for calls that use ``*args`` or ``**kwargs`` unpacking.
 
     RestrictedPython's transformer rewrites ``f(*args, **kwargs)`` into
-    ``_apply_(f, *args, **kwargs)``.  A pass-through is safe here: the AST
-    guards already wrap attribute/item access used to obtain ``f`` and to
-    build the arg/kwarg iterables, so no additional wrapping is required.
+    ``_apply_(f, *args, **kwargs)`` so the sandbox gets a hook on every
+    call whose arg list is built from iterables/mappings rather than
+    statically.  A pass-through is safe here because nothing about
+    iterable-expansion creates new attack surface beyond a plain call:
+
+    1. *f* itself had to be produced by sandboxed code.  Every syntactic
+       path to a callable — ``bare_name``, ``obj.method``, ``d[k]``,
+       ``obj.method()`` — is already rewritten by the AST transformer
+       to go through ``check_name`` / ``_getattr_`` / ``_getitem_`` /
+       ``_apply_`` on the way, so by the time *f* is bound here it
+       has already passed the policy's capability check.
+    2. ``*args`` / ``**kwargs`` unpacking iterates *args* and walks the
+       keys of *kwargs* at the C level; neither operation calls
+       ``__class__``, ``__getattribute__``, or any other introspection
+       hook on the *elements*, and the elements themselves are whatever
+       sandboxed code already had legitimate references to.  There is
+       no way for unpacking to manufacture a new capability.
+    3. The callable's own attribute access during execution still goes
+       through Python's normal descriptor protocol, which the sandbox
+       does not (and cannot) intercept; that is the same trust model
+       as a regular direct call and is not specific to ``_apply_``.
+
+    Consequence: the only thing ``_apply_`` would protect against is a
+    bug in the AST transformer where a ``Call`` reaches this point
+    without its callee having been guarded.  We do not try to paper
+    over that hypothetical here — fix the transformer instead.
     """
     return f(*args, **kwargs)
+
+
+# Maximum total characters a single ``execute`` block may buffer via
+# ``print(...)``.  Prevents a ``while True: print("x")`` from OOM-killing
+# the worker.  ~1 MiB is well above any realistic debug-print volume.
+_MAX_PRINT_CHARS = 1024 * 1024
+
+
+class _BoundedPrintCollector(PrintCollector):
+    """``PrintCollector`` that raises once cumulative output exceeds
+    :data:`_MAX_PRINT_CHARS`.
+
+    The cap is measured against the running total of all chunks ever
+    written, not the current size of ``self.txt`` — clearing the buffer
+    does not reset the budget.
+    """
+
+    def __init__(self, _getattr_: Any = None) -> None:
+        super().__init__(_getattr_=_getattr_)
+        self._total_chars = 0
+
+    def write(self, text: str) -> None:
+        if self._total_chars + len(text) > _MAX_PRINT_CHARS:
+            raise RuntimeError(
+                f"sandbox print() output exceeded {_MAX_PRINT_CHARS} "
+                "characters — terminate the loop or return results "
+                "instead of printing."
+            )
+        self._total_chars += len(text)
+        super().write(text)
 
 
 _NO_DEFAULT = object()
@@ -437,7 +512,7 @@ def _make_globals(
         # uses ``print(...)``.  Rewritten call sites become
         # ``_print._call_print(...)`` on an instance of this class, and the
         # ``printed`` magic name reads back the collected output.
-        "_print_": PrintCollector,
+        "_print_": _BoundedPrintCollector,
         # ``__metaclass__`` is referenced by every ``class`` statement in
         # restricted code: the transformer rewrites ``class C(...)`` to
         # ``class C(..., metaclass=__metaclass__)``.  Plain ``type`` yields

--- a/src/ida_mcp/sandbox.py
+++ b/src/ida_mcp/sandbox.py
@@ -74,10 +74,37 @@ def _forbidden_attr_message(name: str) -> str:
     return f'"{name}" is an invalid attribute name'
 
 
-# AST node kinds that must not appear in an AugAssign target's object
-# expression — the rewrite in ``visit_AugAssign`` would evaluate them
-# twice, diverging from CPython's once-only semantics.
-_DOUBLE_EVAL_NODES = (ast.Call, ast.Subscript)
+def _is_simple_attr_chain(node: ast.expr) -> bool:
+    """True if *node* is a plain ``Name`` or a chain of ``Attribute`` → ``Name``.
+
+    The sandbox rewrite of ``obj.x += y`` evaluates the object expression
+    twice (once on the load side, once on the store side).  That is only
+    observationally equivalent to CPython when the expression is
+    **idempotent** — which we define strictly as "a simple dotted name".
+
+    Anything else is rejected by :meth:`_AsyncRestrictingNodeTransformer.visit_AugAssign`:
+
+    - ``Call`` / ``Subscript`` — obvious side-effect / fresh-wrapper cases
+      (``f().x += 1``, ``obj[k].x += 1``, ctypes struct proxies, NumPy
+      records).  The store would land on a throwaway object and silently
+      vanish.
+    - ``IfExp`` / ``BoolOp`` / ``BinOp`` / ``Lambda`` / ``comprehension``
+      / ... — anything that wraps a computation around the target.  Even
+      when side-effect-free, these may re-compute between load and store
+      if an inner sub-expression depends on state the RHS itself mutates.
+    - ``Attribute`` whose chain bottoms out at anything other than a
+      ``Name`` — walk further and keep checking.
+
+    Dotted-name chains like ``self.counter.n`` pass through.  The only
+    remaining risk is a user-defined ``@property`` with side effects in
+    the chain, which we accept as a documented limitation: a chain of
+    plain attribute lookups is the classic "idempotent" target in
+    Python, and rejecting it would block the most common legitimate
+    augassign patterns (e.g. ``self.n += 1``).
+    """
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    return isinstance(node, ast.Name)
 
 
 class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
@@ -185,14 +212,14 @@ class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
 
         Evaluation order: CPython evaluates ``obj`` once for
         ``obj.x += y`` (DUP_TOP on the object); this rewrite would
-        evaluate ``obj`` twice.  For a simple ``Name`` / ``Attribute``
-        chain (``self.x += 1``, ``self.counter.n += 1``) that's
-        observationally identical — the lookups are idempotent.  But a
-        ``Call`` or ``Subscript`` in the chain can have side effects or
-        return a fresh wrapper per evaluation, so the store would land
-        on a throwaway object and silently vanish: ``f().x += 1``,
-        ``obj[k].x += 1``, ctypes struct proxies, NumPy records.
-        Reject those at compile time and force a temporary:
+        evaluate ``obj`` twice.  We constrain the accepted shape to a
+        **plain dotted name** (:func:`_is_simple_attr_chain`) so the
+        double evaluation only ever re-reads a chain of plain attribute
+        lookups, which is idempotent in all but the pathological
+        side-effecting-``@property`` case — documented as a sandbox
+        limitation.  Anything else (``Call``, ``Subscript``, ``IfExp``,
+        ``BinOp``, ``Lambda``, comprehensions, ...) is rejected at
+        compile time with a "use a temporary" error:
         ``tmp = f(); tmp.x += 1``.
         """
         if isinstance(node.target, ast.Attribute):
@@ -201,25 +228,29 @@ class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
                 self.error(node, _forbidden_attr_message(target.attr))
                 return node
 
-            if any(isinstance(sub, _DOUBLE_EVAL_NODES) for sub in ast.walk(target.value)):
+            if not _is_simple_attr_chain(target.value):
                 self.error(
                     node,
-                    "Augmented assignment on an attribute whose object "
-                    "expression contains a function call or subscript "
-                    "is not supported in the sandbox (the object would "
-                    "be evaluated twice, diverging from CPython).  "
-                    "Assign to a temporary first: "
+                    "Augmented assignment on an attribute target is "
+                    "only supported when the object expression is a "
+                    "plain dotted name (e.g. ``self.n += 1`` or "
+                    "``self.counter.n += 1``).  The sandbox rewrite "
+                    "would evaluate the object twice, diverging from "
+                    "CPython's once-only semantics for any expression "
+                    "containing a call, subscript, or other "
+                    "computation.  Assign to a temporary first: "
                     "tmp = ...; tmp.attr += value",
                 )
                 return node
 
             op_str = IOPERATOR_TO_STR[type(node.op)]
 
-            # Visit the user-supplied subexpressions first so any guards
-            # they need (nested attribute reads, subscripts, ...) are
-            # applied.  Everything below builds guard-wrapped nodes by
-            # hand and must NOT be re-visited — ``_getattr_``, ``_write_``,
-            # and ``_inplacevar_`` names would fail ``check_name``.
+            # Visit the user-supplied subexpressions first so nested
+            # attribute reads in the dotted chain get their usual
+            # ``_getattr_`` guard wrapping.  Everything below builds
+            # guard-wrapped nodes by hand and must NOT be re-visited —
+            # ``_getattr_``, ``_write_``, and ``_inplacevar_`` names
+            # would fail ``check_name``.
             obj_load = self.visit(target.value)
             rhs = self.visit(node.value)
 

--- a/src/ida_mcp/sandbox.py
+++ b/src/ida_mcp/sandbox.py
@@ -74,6 +74,12 @@ def _forbidden_attr_message(name: str) -> str:
     return f'"{name}" is an invalid attribute name'
 
 
+# AST node kinds that must not appear in an AugAssign target's object
+# expression — the rewrite in ``visit_AugAssign`` would evaluate them
+# twice, diverging from CPython's once-only semantics.
+_DOUBLE_EVAL_NODES = (ast.Call, ast.Subscript)
+
+
 class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
     """Extends RestrictedPython's default policy to permit async constructs.
 
@@ -181,12 +187,13 @@ class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
         ``obj.x += y`` (DUP_TOP on the object); this rewrite would
         evaluate ``obj`` twice.  For a simple ``Name`` / ``Attribute``
         chain (``self.x += 1``, ``self.counter.n += 1``) that's
-        observationally identical — the lookups are idempotent.  For a
-        ``Call`` on the chain (``f().x += 1``, ``obj.method().count += 1``)
-        the two evaluations would produce independent objects and the
-        store would vanish.  Rather than silently diverge from CPython,
-        we reject those cases at compile time and force the user to
-        split the statement: ``tmp = f(); tmp.x += 1``.
+        observationally identical — the lookups are idempotent.  But a
+        ``Call`` or ``Subscript`` in the chain can have side effects or
+        return a fresh wrapper per evaluation, so the store would land
+        on a throwaway object and silently vanish: ``f().x += 1``,
+        ``obj[k].x += 1``, ctypes struct proxies, NumPy records.
+        Reject those at compile time and force a temporary:
+        ``tmp = f(); tmp.x += 1``.
         """
         if isinstance(node.target, ast.Attribute):
             target = node.target
@@ -194,13 +201,14 @@ class _AsyncRestrictingNodeTransformer(RestrictingNodeTransformer):
                 self.error(node, _forbidden_attr_message(target.attr))
                 return node
 
-            if any(isinstance(sub, ast.Call) for sub in ast.walk(target.value)):
+            if any(isinstance(sub, _DOUBLE_EVAL_NODES) for sub in ast.walk(target.value)):
                 self.error(
                     node,
                     "Augmented assignment on an attribute whose object "
-                    "expression contains a function call is not "
-                    "supported in the sandbox (the object would be "
-                    "evaluated twice).  Assign to a temporary first: "
+                    "expression contains a function call or subscript "
+                    "is not supported in the sandbox (the object would "
+                    "be evaluated twice, diverging from CPython).  "
+                    "Assign to a temporary first: "
                     "tmp = ...; tmp.attr += value",
                 )
                 return node

--- a/src/ida_mcp/session.py
+++ b/src/ida_mcp/session.py
@@ -27,6 +27,7 @@ from ida_mcp.exceptions import (
     PRIMARY_IDB_EXTENSIONS,
     append_output_flag,
     reject_fat_arch_on_database,
+    reject_force_new_on_database,
     slice_sidecar_stem,
 )
 from ida_mcp.helpers import Cancelled, IDAError
@@ -108,17 +109,23 @@ class Session:
 
         # If the user passed an IDA database file, derive the binary path
         # (which is what idalib expects) and allow opening even when only
-        # the database exists.  ``check_fat_binary`` already runs this
-        # same fat_arch-on-database guard from the supervisor fail-fast
-        # path, but repeat it here so direct Session.open callers
-        # (standalone workers, tests) get the same behavior.  The
-        # ``realpath`` above means a symlink-without-extension pointing
-        # at a ``.i64`` is caught here the same as a direct path.
+        # the database exists.  ``check_fat_binary`` already runs these
+        # fat_arch / force_new guards from the supervisor fail-fast path,
+        # but repeat them here so direct Session.open callers (standalone
+        # workers, tests) get the same behavior.  Both helpers realpath
+        # internally, so a symlink-without-extension pointing at a
+        # ``.i64`` is caught here the same as a direct path.
         stem, ext = os.path.splitext(path)
         if ext.lower() in PRIMARY_IDB_EXTENSIONS:
             if not os.path.isfile(path):
                 raise IDAError(f"Database not found: {path}", error_type="FileNotFoundError")
-            reject_fat_arch_on_database(path, fat_arch)
+            # Use the caller-supplied ``file_path`` so error messages
+            # show what the user typed, not the realpath'd target.
+            reject_fat_arch_on_database(file_path, fat_arch)
+            # Catch force_new+database before the force_new loop below
+            # deletes the stored analysis — once we're past this point,
+            # the .i64 the user pointed at is gone.
+            reject_force_new_on_database(file_path, force_new)
             # IDA expects the stem path; it finds the .i64 on its own.
             path = stem
         elif not os.path.isfile(path):

--- a/src/ida_mcp/session.py
+++ b/src/ida_mcp/session.py
@@ -14,6 +14,7 @@ import functools
 import inspect
 import logging
 import os
+import re
 import signal
 
 import ida_auto
@@ -23,7 +24,7 @@ import ida_idp
 import ida_kernwin
 import idapro
 
-from ida_mcp.exceptions import PRIMARY_IDB_EXTENSIONS
+from ida_mcp.exceptions import PRIMARY_IDB_EXTENSIONS, quote_ida_arg, slice_sidecar_stem
 from ida_mcp.helpers import Cancelled, IDAError
 
 log = logging.getLogger(__name__)
@@ -41,6 +42,56 @@ _ERROR_CODES: dict[int, str] = {
 
 # File extensions created by IDA alongside the input binary.
 _IDB_EXTENSIONS: tuple[str, ...] = (".i64", ".idb", ".id0", ".id1", ".id2", ".nam", ".til")
+
+
+def _append_output_flag(options: str | None, target_stem: str) -> str:
+    """Return *options* with a ``-o<target_stem>`` flag appended.
+
+    Used for a first-time fat-slice open: IDA writes the new ``.i64``
+    at ``target_stem.i64`` instead of the default stem-alongside-input
+    location.
+    """
+    flag = f"-o{quote_ida_arg(target_stem)}"
+    if not options:
+        return flag
+    return f"{options} {flag}"
+
+
+# Matches a ``-T`` flag and its value (``-TELF``, ``-T"Fat Mach-O file, 2"``
+# or ``-T'Fat Mach-O file, 2'``), or a ``-o<path>`` flag with an optional
+# quoted-or-unquoted argument.  The bounded ``[^"]*`` / ``[^']*`` quoted
+# alternates stop at the closing quote so the bare-value branch can't
+# swallow later args.
+_FAT_FLAG_RE = re.compile(
+    r"""
+    (?:^|\s)                    # leading whitespace or line start
+    -(?:T|o)                    # -T or -o
+    (?:                         # value immediately after the flag
+        "[^"]*"                 # "double quoted"
+      | '[^']*'                 # 'single quoted'
+      | \S+                     # or bare run of non-space chars
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def _strip_fat_flags(options: str | None) -> str | None:
+    """Remove ``-T`` and ``-o`` flags from an IDA args string.
+
+    Called when reusing a pre-existing slice-specific sidecar as a
+    defensive scrub: ``build_ida_args`` normally omits ``-T`` in this
+    case (``check_fat_binary`` short-circuited) so this is a no-op on
+    the happy path, but a direct caller that passed raw ``-T`` /
+    ``-o`` flags via *options* would confuse IDA on a stored-DB
+    reopen — ``-T`` is ignored, ``-o`` implies ``-c`` (fresh).
+    Returns ``None`` if nothing remains after stripping (so callers
+    get IDA's "no args" path instead of an empty string).
+    """
+    if not options:
+        return options
+    cleaned = _FAT_FLAG_RE.sub("", options).strip()
+    return cleaned or None
 
 
 class Session:
@@ -63,6 +114,7 @@ class Session:
         run_auto_analysis: bool = False,
         force_new: bool = False,
         options: str | None = None,
+        fat_arch: str = "",
     ) -> dict:
         """Open a binary for analysis. Auto-closes any previously open database.
 
@@ -72,60 +124,111 @@ class Session:
         (``.i64`` / ``.idb``).  When a database path is given, IDA opens it
         directly — the original binary does not need to be present.
 
-        When *force_new* is ``True``, any existing IDA database files
-        alongside the binary (``.i64``, ``.idb``, etc.) are deleted before
-        opening, forcing a fresh analysis from the raw binary.
+        When *force_new* is ``True``, any existing IDA database files for
+        the target stem are deleted before opening, forcing a fresh
+        analysis from the raw binary.  When *fat_arch* is set, only the
+        slice-specific sidecars are removed — other slices' databases
+        are left alone.
 
         *options* is an optional string of additional IDA command-line
-        arguments (e.g. ``-parm`` to select the ARM processor module,
-        ``-TGeneric`` for a specific loader).
+        arguments (e.g. ``-parm`` to select the ARM processor module).
+        The caller is expected to have built ``options`` via
+        :func:`build_ida_args`; for a first-time fat-slice open,
+        ``options`` already contains the matching
+        ``-T"Fat Mach-O file, <index>"`` flag and this method appends
+        ``-o<stem>`` so each slice writes to its own database file.
+        For a reuse open, ``check_fat_binary`` short-circuits and
+        ``build_ida_args`` omits the ``-T`` flag — nothing to add here.
+
+        *fat_arch* — when set, each slice lives at its own sidecar stem
+        (``<binary>.<slice>``) so multiple architectures of the same
+        universal binary can coexist on disk without overwriting each
+        other's analysis.  Pre-existing slice-specific DBs are reused
+        automatically; fresh opens get an explicit ``-o<stem>`` flag so
+        IDA writes the new ``.i64`` at the per-slice location instead
+        of the default ``<binary>.i64`` path.
         """
         path = os.path.abspath(os.path.expanduser(file_path))
 
         # If the user passed an IDA database file, derive the binary path
         # (which is what idalib expects) and allow opening even when only the
-        # database exists.
+        # database exists.  An explicit database path already pins a
+        # specific slice, so fat_arch is meaningless in that branch and
+        # we silently drop it.
         _, ext = os.path.splitext(path)
         if ext.lower() in PRIMARY_IDB_EXTENSIONS:
-            binary_path = os.path.splitext(path)[0]
             if not os.path.isfile(path):
                 raise IDAError(f"Database not found: {path}", error_type="FileNotFoundError")
             # IDA expects the stem path; it finds the .i64 on its own.
-            path = binary_path
+            path = os.path.splitext(path)[0]
+            fat_arch = ""
         elif not os.path.isfile(path):
             raise IDAError(f"File not found: {path}", error_type="FileNotFoundError")
 
         if self.is_open():
             self.close(save=True)
 
+        # Slice-specific sidecar stem.  For thin / non-fat opens this
+        # collapses to ``path``.
+        target_stem = slice_sidecar_stem(path, fat_arch)
+        target_db = target_stem + ".i64"
+
         if force_new:
-            # Use the full path as the base — IDA creates sidecar files by
-            # appending extensions to the binary path (e.g. foo.exe → foo.exe.i64).
-            # When the user passed a .i64/.idb, `path` was already set to
-            # the stem (line above) so this still works for that case.
-            base = path
-            for ext in _IDB_EXTENSIONS:
-                db_file = base + ext
+            # Delete only the target sidecar files so a force_new on one
+            # slice doesn't nuke another slice's saved analysis.
+            for db_ext in _IDB_EXTENSIONS:
+                db_file = target_stem + db_ext
                 if os.path.isfile(db_file):
                     log.info("force_new: removing %s", db_file)
                     os.remove(db_file)
 
+        sidecar_exists = os.path.isfile(target_db)
+
+        if fat_arch and sidecar_exists:
+            # Reuse the slice-specific stored database.  IDA picks up
+            # target_db by reading from target_stem; target_stem itself
+            # does not need to exist as a real file on disk.  Scrub any
+            # stray -T / -o flags from *options* as a defensive measure
+            # (build_ida_args normally omits them in this branch): -T
+            # would be ignored by IDA on a stored-DB open and -o implies
+            # -c (fresh), either of which would surprise the caller.
+            ida_input = target_stem
+            ida_args = _strip_fat_flags(options)
+        elif fat_arch:
+            # First-time analysis of a specific fat slice.  Redirect the
+            # output database to the slice-specific stem via ``-o`` so
+            # the resulting sidecar is ``<binary>.<slice>.i64``.  The
+            # caller has already embedded the matching ``-T"Fat Mach-O
+            # file, N"`` flag in *options*.
+            ida_input = path
+            ida_args = _append_output_flag(options, target_stem)
+        else:
+            # Thin binary, default slice (fat_arch=""), or a fat binary
+            # whose default sidecar already exists.
+            ida_input = path
+            ida_args = options
+
         log.debug(
             "Calling idapro.open_database(%s, run_auto_analysis=%s, args=%r)",
-            path,
+            ida_input,
             run_auto_analysis,
-            options,
+            ida_args,
         )
-        result = idapro.open_database(path, run_auto_analysis, args=options)
+        result = idapro.open_database(ida_input, run_auto_analysis, args=ida_args)
         if result != 0:
             message = _ERROR_CODES.get(result, f"Unknown error (code {result})")
             log.error("idapro.open_database returned error code %d: %s", result, message)
             raise IDAError(f"Failed to open database: {message}", error_type="RuntimeError")
 
-        self._current_path = path
+        # ``_current_path`` is the stem IDA's sidecars live under, which
+        # is the slice-specific stem when fat_arch was set (regardless
+        # of whether this was a fresh ``-o`` open or a reuse).  Reporting
+        # this to downstream callers (close/save/list) gives them a
+        # path that actually corresponds to a ``.i64`` on disk.
+        self._current_path = target_stem
         self.capabilities = self._probe_capabilities()
-        log.info("Opened database: %s (capabilities: %s)", path, self.capabilities)
-        return {"status": "ok", "path": path}
+        log.info("Opened database: %s (capabilities: %s)", target_stem, self.capabilities)
+        return {"status": "ok", "path": target_stem}
 
     def _probe_capabilities(self) -> dict[str, bool]:
         """Detect which optional features are available for the current database."""

--- a/src/ida_mcp/session.py
+++ b/src/ida_mcp/session.py
@@ -109,7 +109,10 @@ class Session:
         IDA writes the new ``.i64`` at the per-slice location instead
         of the default ``<binary>.i64`` path.
         """
-        path = os.path.abspath(os.path.expanduser(file_path))
+        # realpath (not abspath) so symlinks collapse to the real binary,
+        # matching worker_provider._canonical_path's dedup key and
+        # slice_sidecar_stem's storage stem.
+        path = os.path.realpath(os.path.expanduser(file_path))
 
         # If the user passed an IDA database file, derive the binary path
         # (which is what idalib expects) and allow opening even when only the

--- a/src/ida_mcp/session.py
+++ b/src/ida_mcp/session.py
@@ -23,7 +23,12 @@ import ida_idp
 import ida_kernwin
 import idapro
 
-from ida_mcp.exceptions import PRIMARY_IDB_EXTENSIONS, quote_ida_arg, slice_sidecar_stem
+from ida_mcp.exceptions import (
+    PRIMARY_IDB_EXTENSIONS,
+    append_output_flag,
+    reject_fat_arch_on_database,
+    slice_sidecar_stem,
+)
 from ida_mcp.helpers import Cancelled, IDAError
 
 log = logging.getLogger(__name__)
@@ -41,19 +46,6 @@ _ERROR_CODES: dict[int, str] = {
 
 # File extensions created by IDA alongside the input binary.
 _IDB_EXTENSIONS: tuple[str, ...] = (".i64", ".idb", ".id0", ".id1", ".id2", ".nam", ".til")
-
-
-def _append_output_flag(options: str | None, target_stem: str) -> str:
-    """Return *options* with a ``-o<target_stem>`` flag appended.
-
-    Used for a first-time fat-slice open: IDA writes the new ``.i64``
-    at ``target_stem.i64`` instead of the default stem-alongside-input
-    location.
-    """
-    flag = f"-o{quote_ida_arg(target_stem)}"
-    if not options:
-        return flag
-    return f"{options} {flag}"
 
 
 class Session:
@@ -115,17 +107,20 @@ class Session:
         path = os.path.realpath(os.path.expanduser(file_path))
 
         # If the user passed an IDA database file, derive the binary path
-        # (which is what idalib expects) and allow opening even when only the
-        # database exists.  An explicit database path already pins a
-        # specific slice, so fat_arch is meaningless in that branch and
-        # we silently drop it.
-        _, ext = os.path.splitext(path)
+        # (which is what idalib expects) and allow opening even when only
+        # the database exists.  ``check_fat_binary`` already runs this
+        # same fat_arch-on-database guard from the supervisor fail-fast
+        # path, but repeat it here so direct Session.open callers
+        # (standalone workers, tests) get the same behavior.  The
+        # ``realpath`` above means a symlink-without-extension pointing
+        # at a ``.i64`` is caught here the same as a direct path.
+        stem, ext = os.path.splitext(path)
         if ext.lower() in PRIMARY_IDB_EXTENSIONS:
             if not os.path.isfile(path):
                 raise IDAError(f"Database not found: {path}", error_type="FileNotFoundError")
+            reject_fat_arch_on_database(path, fat_arch)
             # IDA expects the stem path; it finds the .i64 on its own.
-            path = os.path.splitext(path)[0]
-            fat_arch = ""
+            path = stem
         elif not os.path.isfile(path):
             raise IDAError(f"File not found: {path}", error_type="FileNotFoundError")
 
@@ -161,7 +156,7 @@ class Session:
             # caller has already embedded the matching ``-T"Fat Mach-O
             # file, N"`` flag in *options*.
             ida_input = path
-            ida_args = _append_output_flag(options, target_stem)
+            ida_args = append_output_flag(options, target_stem)
         else:
             # Thin binary, default slice (fat_arch=""), or a fat binary
             # whose default sidecar already exists.

--- a/src/ida_mcp/session.py
+++ b/src/ida_mcp/session.py
@@ -14,7 +14,6 @@ import functools
 import inspect
 import logging
 import os
-import re
 import signal
 
 import ida_auto
@@ -57,43 +56,6 @@ def _append_output_flag(options: str | None, target_stem: str) -> str:
     return f"{options} {flag}"
 
 
-# Matches a ``-T`` flag and its value (``-TELF``, ``-T"Fat Mach-O file, 2"``
-# or ``-T'Fat Mach-O file, 2'``), or a ``-o<path>`` flag with an optional
-# quoted-or-unquoted argument.  The bounded ``[^"]*`` / ``[^']*`` quoted
-# alternates stop at the closing quote so the bare-value branch can't
-# swallow later args.
-_FAT_FLAG_RE = re.compile(
-    r"""
-    (?:^|\s)                    # leading whitespace or line start
-    -(?:T|o)                    # -T or -o
-    (?:                         # value immediately after the flag
-        "[^"]*"                 # "double quoted"
-      | '[^']*'                 # 'single quoted'
-      | \S+                     # or bare run of non-space chars
-    )
-    """,
-    re.VERBOSE,
-)
-
-
-def _strip_fat_flags(options: str | None) -> str | None:
-    """Remove ``-T`` and ``-o`` flags from an IDA args string.
-
-    Called when reusing a pre-existing slice-specific sidecar as a
-    defensive scrub: ``build_ida_args`` normally omits ``-T`` in this
-    case (``check_fat_binary`` short-circuited) so this is a no-op on
-    the happy path, but a direct caller that passed raw ``-T`` /
-    ``-o`` flags via *options* would confuse IDA on a stored-DB
-    reopen — ``-T`` is ignored, ``-o`` implies ``-c`` (fresh).
-    Returns ``None`` if nothing remains after stripping (so callers
-    get IDA's "no args" path instead of an empty string).
-    """
-    if not options:
-        return options
-    cleaned = _FAT_FLAG_RE.sub("", options).strip()
-    return cleaned or None
-
-
 class Session:
     """Singleton managing the single idalib database session."""
 
@@ -132,13 +94,12 @@ class Session:
 
         *options* is an optional string of additional IDA command-line
         arguments (e.g. ``-parm`` to select the ARM processor module).
-        The caller is expected to have built ``options`` via
-        :func:`build_ida_args`; for a first-time fat-slice open,
-        ``options`` already contains the matching
-        ``-T"Fat Mach-O file, <index>"`` flag and this method appends
-        ``-o<stem>`` so each slice writes to its own database file.
-        For a reuse open, ``check_fat_binary`` short-circuits and
-        ``build_ida_args`` omits the ``-T`` flag — nothing to add here.
+        Callers **must** build ``options`` via :func:`build_ida_args`;
+        it is concatenated into ``idapro.open_database``'s ``args=``
+        verbatim.  In particular, ``-T<loader>`` and ``-o<stem>`` must
+        not appear in *options* — fat-slice selection goes through
+        ``build_ida_args(fat_slice_index=...)`` and this method owns
+        the ``-o`` stem redirect for fresh slice opens.
 
         *fat_arch* — when set, each slice lives at its own sidecar stem
         (``<binary>.<slice>``) so multiple architectures of the same
@@ -187,13 +148,9 @@ class Session:
         if fat_arch and sidecar_exists:
             # Reuse the slice-specific stored database.  IDA picks up
             # target_db by reading from target_stem; target_stem itself
-            # does not need to exist as a real file on disk.  Scrub any
-            # stray -T / -o flags from *options* as a defensive measure
-            # (build_ida_args normally omits them in this branch): -T
-            # would be ignored by IDA on a stored-DB open and -o implies
-            # -c (fresh), either of which would surprise the caller.
+            # does not need to exist as a real file on disk.
             ida_input = target_stem
-            ida_args = _strip_fat_flags(options)
+            ida_args = options
         elif fat_arch:
             # First-time analysis of a specific fat slice.  Redirect the
             # output database to the slice-specific stem via ``-o`` so

--- a/src/ida_mcp/supervisor.py
+++ b/src/ida_mcp/supervisor.py
@@ -309,7 +309,11 @@ class ProxyMCP(FastMCP):
             slices in its ``available`` detail — there is no separate
             "list slices" call.  To analyze multiple slices from the same
             file concurrently, call open_database once per slice with
-            distinct ``database_id`` values.
+            distinct ``database_id`` values.  Conversely, passing
+            *fat_arch* on a file that is **not** a fat Mach-O (thin
+            binary, ELF, firmware blob, ...) is rejected with
+            ``InvalidArgument`` rather than silently ignored, so a typo
+            cannot produce a confusingly suffixed sidecar on disk.
 
             Args:
                 file_path: Path to the binary file or IDA database.
@@ -339,10 +343,11 @@ class ProxyMCP(FastMCP):
                 fat_arch: Optional.  Architecture slice name to extract
                           from a Mach-O fat (universal) binary —
                           ``x86_64``, ``arm64``, ``arm64e``, etc.  Required
-                          when opening a fat binary; ignored for thin
-                          files.  Cannot be combined with *loader* — both
-                          map to IDA's ``-T`` flag and fat_arch implicitly
-                          selects the Fat Mach-O loader.
+                          when opening a fat binary; must be omitted for
+                          thin files (passing it on a non-fat file raises
+                          ``InvalidArgument``).  Cannot be combined with
+                          *loader* — both map to IDA's ``-T`` flag and
+                          fat_arch implicitly selects the Fat Mach-O loader.
                 options: Optional.  Additional IDA command-line arguments.
                          Processor, loader, and base address flags are added
                          automatically from the other parameters — do not

--- a/src/ida_mcp/supervisor.py
+++ b/src/ida_mcp/supervisor.py
@@ -11,7 +11,7 @@ Prompts are registered directly on the supervisor.
 All tools except management tools (``open_database``, ``close_database``,
 ``save_database``, ``list_databases``, ``wait_for_analysis``,
 ``list_targets``) require the ``database`` parameter (the stem ID
-returned by ``open_database``).
+returned by ``open_database`` or ``list_databases``).
 
 The supervisor never imports ``idapro`` or any ``ida_*`` module.
 """
@@ -28,7 +28,12 @@ from fastmcp import FastMCP
 
 from ida_mcp import find_ida_dir
 from ida_mcp.context import try_get_context
-from ida_mcp.exceptions import IDAError, check_processor_ambiguity
+from ida_mcp.exceptions import (
+    IDAError,
+    build_ida_args,
+    check_fat_binary,
+    check_processor_ambiguity,
+)
 from ida_mcp.prompts import register_all as register_prompts
 from ida_mcp.transforms import IDAToolTransform
 from ida_mcp.worker_provider import (
@@ -114,7 +119,7 @@ class ProxyMCP(FastMCP):
             "**Multi-database wait:** pass databases=[...] to "
             "wait_for_analysis to wait for several at once. It returns "
             "as soon as at least one is ready — start working on it "
-            "while others load.  Call again for the remaining ones.\n\n"
+            "while others load. Call again for the remaining ones.\n\n"
             "**Important:** while analysis is running, the IDA thread is "
             "blocked — tool calls will queue until analysis completes. "
             "Always call wait_for_analysis before using other tools.\n\n"
@@ -124,14 +129,21 @@ class ProxyMCP(FastMCP):
             "The binary must be in a writable directory (IDA creates a "
             ".i64 database alongside it); copy read-only files to a "
             "writable location first.\n\n"
+            "**Fat Mach-O binaries:** universal binaries require an "
+            'explicit fat_arch= (e.g. "x86_64", "arm64", "arm64e"). '
+            "Without it, open_database raises AmbiguousFatBinary with "
+            "the available slices listed in the error's available field. "
+            "To analyze multiple slices from the same file concurrently, "
+            "call open_database once per slice with distinct database_id "
+            "values.\n\n"
             #
             # --- Addressing ---
             #
             "## Addressing\n"
             "All tools except management tools (open_database, "
-            "close_database, list_databases, wait_for_analysis, "
-            "save_database, list_targets) require the database parameter — the stem ID "
-            "returned by open_database.\n\n"
+            "close_database, save_database, list_databases, "
+            "wait_for_analysis, list_targets) require the database parameter — the stem ID "
+            "returned by open_database or list_databases.\n\n"
             'Addresses accept hex strings ("0x401000"), bare hex '
             '("4010a0"), decimal, or symbol names ("main").\n\n'
             #
@@ -151,7 +163,7 @@ class ProxyMCP(FastMCP):
             "Multiple independent calls (same or different tools)? → "
             "Use **batch** (up to 50 operations per request, sequential "
             "with per-item error collection and progress reporting). "
-            "Prefer batch over execute — it is simpler and more robust.\n\n"
+            "Prefer batch over execute — it is simpler.\n\n"
             "Conditional logic, filtering results, or chaining tool A "
             "output into tool B? → Use **execute** with "
             "`await call_tool(name, params)` for Python control flow.\n\n"
@@ -163,13 +175,13 @@ class ProxyMCP(FastMCP):
             # --- Tool discovery ---
             #
             "## Tool discovery\n"
-            "Common analysis tools are pinned and always visible.  "
+            "Common analysis tools are pinned and always visible. "
             "Additional tools are discoverable via search_tools(pattern) "
             "and callable directly by name, or through execute/batch. "
             "Hidden tools work identically to pinned tools — no special "
             "syntax required.\n\n"
-            "Management tools (open_database, close_database, list_databases, "
-            "wait_for_analysis, save_database, list_targets) are always visible "
+            "Management tools (open_database, close_database, save_database, "
+            "list_databases, wait_for_analysis, list_targets) are always visible "
             "and called directly — not through execute or batch.\n\n"
             #
             # --- Session trust ---
@@ -206,9 +218,9 @@ class ProxyMCP(FastMCP):
             "dispatch tables, and token dictionaries — auto-dereferences "
             "pointers and detects strings at targets.\n"
             "- Raw binary / firmware: open with processor and loader "
-            "set explicitly.  **ARM gotcha:** the arm module defaults "
+            "set explicitly. **ARM gotcha:** the arm module defaults "
             'to AArch64 for raw binaries — use "arm:ARMv7-M" for '
-            'Cortex-M, not just "arm".  Use list_targets to see '
+            'Cortex-M, not just "arm". Use list_targets to see '
             "available processors and loaders. "
             "After opening, use rebase_program to set the correct base "
             "address, create_segment for memory-mapped regions (MMIO, "
@@ -242,6 +254,7 @@ class ProxyMCP(FastMCP):
             processor: str = "",
             loader: str = "",
             base_address: str = "",
+            fat_arch: str = "",
             options: str = "",
         ) -> dict:
             """Open a binary or existing IDA database for analysis.
@@ -288,6 +301,16 @@ class ProxyMCP(FastMCP):
             *processor* and *loader* to override when auto-detection picks
             the wrong option (e.g. a raw firmware blob with no headers).
 
+            **Fat Mach-O binaries:** universal ("fat") Mach-O files pack
+            multiple architecture slices (e.g. ``x86_64`` + ``arm64``) into
+            a single file.  In headless mode IDA would silently pick a
+            default slice, so open_database refuses to open a fat binary
+            without an explicit *fat_arch*.  The error lists available
+            slices in its ``available`` detail — there is no separate
+            "list slices" call.  To analyze multiple slices from the same
+            file concurrently, call open_database once per slice with
+            distinct ``database_id`` values.
+
             Args:
                 file_path: Path to the binary file or IDA database.
                 run_auto_analysis: Wait for IDA auto-analysis after opening.
@@ -313,13 +336,33 @@ class ProxyMCP(FastMCP):
                               16-byte aligned.  Primarily useful for raw
                               binary files; structured formats contain their
                               own base addresses.
+                fat_arch: Optional.  Architecture slice name to extract
+                          from a Mach-O fat (universal) binary —
+                          ``x86_64``, ``arm64``, ``arm64e``, etc.  Required
+                          when opening a fat binary; ignored for thin
+                          files.  Cannot be combined with *loader* — both
+                          map to IDA's ``-T`` flag and fat_arch implicitly
+                          selects the Fat Mach-O loader.
                 options: Optional.  Additional IDA command-line arguments.
                          Processor, loader, and base address flags are added
                          automatically from the other parameters — do not
                          duplicate them here.
             """
-            # Fail fast on ambiguous processor before spawning a worker.
-            check_processor_ambiguity(processor, file_path, force_new)
+            # Fail fast on ambiguous processor / fat binary / bad arg
+            # combinations before spawning (or reusing) a worker.  The
+            # worker re-runs these checks for standalone safety, so we
+            # discard the returned values — but catching errors here
+            # means misconfigured args fail even when dedup would
+            # otherwise return an existing worker.
+            check_processor_ambiguity(processor, file_path, force_new, fat_arch)
+            fat_slice_index = check_fat_binary(file_path, fat_arch, force_new)
+            build_ida_args(
+                processor=processor,
+                loader=loader,
+                base_address=base_address,
+                fat_slice_index=fat_slice_index,
+                options=options,
+            )
 
             ctx = try_get_context()
             sid = ctx.session_id if ctx else None
@@ -338,6 +381,7 @@ class ProxyMCP(FastMCP):
                 processor=processor,
                 loader=loader,
                 base_address=base_address,
+                fat_arch=fat_arch,
                 options=options,
             )
             await _notify_resources_changed()

--- a/src/ida_mcp/supervisor.py
+++ b/src/ida_mcp/supervisor.py
@@ -309,11 +309,14 @@ class ProxyMCP(FastMCP):
             slices in its ``available`` detail — there is no separate
             "list slices" call.  To analyze multiple slices from the same
             file concurrently, call open_database once per slice with
-            distinct ``database_id`` values.  Conversely, passing
-            *fat_arch* on a file that is **not** a fat Mach-O (thin
-            binary, ELF, firmware blob, ...) is rejected with
+            distinct ``database_id`` values.  Conversely, *fat_arch* must
+            be omitted when the file is not a fat Mach-O (thin binary,
+            ELF, firmware blob, ...) and when *file_path* points at an
+            existing ``.i64``/``.idb`` (the stored database already pins
+            a slice); either combination is rejected with
             ``InvalidArgument`` rather than silently ignored, so a typo
-            cannot produce a confusingly suffixed sidecar on disk.
+            cannot produce a confusingly suffixed sidecar on disk or a
+            reopen that unexpectedly does not swap slices.
 
             Args:
                 file_path: Path to the binary file or IDA database.
@@ -344,10 +347,12 @@ class ProxyMCP(FastMCP):
                           from a Mach-O fat (universal) binary —
                           ``x86_64``, ``arm64``, ``arm64e``, etc.  Required
                           when opening a fat binary; must be omitted for
-                          thin files (passing it on a non-fat file raises
-                          ``InvalidArgument``).  Cannot be combined with
-                          *loader* — both map to IDA's ``-T`` flag and
-                          fat_arch implicitly selects the Fat Mach-O loader.
+                          thin / non-Mach-O files **and** for existing
+                          ``.i64``/``.idb`` database paths — either
+                          combination raises ``InvalidArgument``.  Cannot
+                          be combined with *loader* either, since both
+                          map to IDA's ``-T`` flag and fat_arch
+                          implicitly selects the Fat Mach-O loader.
                 options: Optional.  Additional IDA command-line arguments.
                          Processor, loader, and base address flags are added
                          automatically from the other parameters — do not

--- a/src/ida_mcp/tools/database.py
+++ b/src/ida_mcp/tools/database.py
@@ -204,8 +204,10 @@ def register(mcp: FastMCP):
                       Mach-O fat (universal) binary.  Required when
                       opening a fat binary — the error on a missing
                       slice lists the available names.  Must be
-                      omitted for thin / non-Mach-O files; passing it
-                      on such a file raises ``InvalidArgument``.
+                      omitted for thin / non-Mach-O files **and** for
+                      explicit ``.i64``/``.idb`` database paths
+                      (stored analysis already pins the slice);
+                      either combination raises ``InvalidArgument``.
             options: Optional.  Additional IDA command-line arguments.
                      Processor, loader, and base address flags are added
                      automatically from the other parameters — do not

--- a/src/ida_mcp/tools/database.py
+++ b/src/ida_mcp/tools/database.py
@@ -17,7 +17,7 @@ import ida_segment
 from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
-from ida_mcp.exceptions import build_ida_args, check_processor_ambiguity
+from ida_mcp.exceptions import build_ida_args, check_fat_binary, check_processor_ambiguity
 from ida_mcp.helpers import (
     ANNO_DESTRUCTIVE,
     ANNO_MUTATE,
@@ -160,6 +160,7 @@ def register(mcp: FastMCP):
         processor: str = "",
         loader: str = "",
         base_address: str = "",
+        fat_arch: str = "",
         options: str = "",
     ) -> OpenDatabaseResult:
         """Open a binary or existing IDA database for analysis.
@@ -198,21 +199,39 @@ def register(mcp: FastMCP):
                           Primarily useful for raw binary files; structured
                           formats (ELF, PE, Mach-O) contain their own base
                           addresses.
+            fat_arch: Optional.  Architecture slice name (``x86_64``,
+                      ``arm64``, ``arm64e``, ...) to extract from a
+                      Mach-O fat (universal) binary.  Required when
+                      opening a fat binary — the error on a missing
+                      slice lists the available names.  Ignored for
+                      thin files.
             options: Optional.  Additional IDA command-line arguments.
                      Processor, loader, and base address flags are added
                      automatically from the other parameters — do not
                      duplicate them here.
         """
-        # The supervisor also calls check_processor_ambiguity before spawning
-        # the worker (fail-fast).  We repeat it here so the worker's own
-        # open_database tool is safe when used standalone (e.g. direct worker
-        # connections or tests).
-        check_processor_ambiguity(processor, file_path, force_new)
+        # The supervisor also runs these fail-fast checks before spawning
+        # the worker.  We repeat them here so the worker's own open_database
+        # tool is safe when used standalone (e.g. direct worker connections
+        # or tests).  check_fat_binary returns the 1-based slice index
+        # (or None when no -T flag is needed) which feeds into build_ida_args.
+        check_processor_ambiguity(processor, file_path, force_new, fat_arch)
+        fat_slice_index = check_fat_binary(file_path, fat_arch, force_new)
         ida_args = build_ida_args(
-            processor=processor, loader=loader, base_address=base_address, options=options
+            processor=processor,
+            loader=loader,
+            base_address=base_address,
+            fat_slice_index=fat_slice_index,
+            options=options,
         )
 
-        session.open(file_path, run_auto_analysis, force_new=force_new, options=ida_args)
+        session.open(
+            file_path,
+            run_auto_analysis,
+            force_new=force_new,
+            options=ida_args,
+            fat_arch=fat_arch,
+        )
 
         return OpenDatabaseResult(
             status="ok",

--- a/src/ida_mcp/tools/database.py
+++ b/src/ida_mcp/tools/database.py
@@ -203,8 +203,9 @@ def register(mcp: FastMCP):
                       ``arm64``, ``arm64e``, ...) to extract from a
                       Mach-O fat (universal) binary.  Required when
                       opening a fat binary — the error on a missing
-                      slice lists the available names.  Ignored for
-                      thin files.
+                      slice lists the available names.  Must be
+                      omitted for thin / non-Mach-O files; passing it
+                      on such a file raises ``InvalidArgument``.
             options: Optional.  Additional IDA command-line arguments.
                      Processor, loader, and base address flags are added
                      automatically from the other parameters — do not

--- a/src/ida_mcp/transforms.py
+++ b/src/ida_mcp/transforms.py
@@ -162,8 +162,8 @@ Cross-database parallel queries?
 
 **Important:**
 - Only IDA analysis tools are callable via `call_tool` inside execute. \
-Management tools (open_database, close_database, list_databases, \
-wait_for_analysis, save_database, list_targets) and meta-tools \
+Management tools (open_database, close_database, save_database, \
+list_databases, wait_for_analysis, list_targets) and meta-tools \
 (search_tools, execute, batch) must be called directly — they are \
 not available inside execute.
 - `database` is auto-injected into every `call_tool` invocation. \

--- a/src/ida_mcp/worker_provider.py
+++ b/src/ida_mcp/worker_provider.py
@@ -166,8 +166,9 @@ def _canonical_path(path: str, fat_arch: str = "") -> str:
 
     Accepts a raw binary path or an existing ``.i64``/``.idb`` path.
     Always resolves to the ``.i64`` so that either input maps to the
-    same worker.  Uses ``realpath`` (not just ``abspath``) so two
-    symlinks pointing at the same file dedup to the same worker.
+    same worker.  Uses ``realpath`` (via :func:`slice_sidecar_stem`)
+    so two symlinks pointing at the same file dedup to the same
+    worker.
 
     When *fat_arch* is set, the key includes the slice suffix so
     different architectures of the same universal binary dedup to
@@ -175,10 +176,10 @@ def _canonical_path(path: str, fat_arch: str = "") -> str:
     ``.i64``/``.idb`` inputs ignore *fat_arch* — the stored database
     already pins a specific slice.
     """
-    resolved = os.path.realpath(os.path.expanduser(path))
     # slice_sidecar_stem gives us ``<binary>`` or ``<binary>.<slice>``
-    # (or ``<db>`` for an explicit .i64/.idb); append .i64 for the key.
-    return slice_sidecar_stem(resolved, fat_arch) + ".i64"
+    # (or ``<db>`` for an explicit .i64/.idb) and already realpath's
+    # its input, so we don't need a second resolution pass here.
+    return slice_sidecar_stem(path, fat_arch) + ".i64"
 
 
 def _normalize_id(stem: str) -> str:

--- a/src/ida_mcp/worker_provider.py
+++ b/src/ida_mcp/worker_provider.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from mcp.server.session import ServerSession
 
 from ida_mcp.context import try_get_context
-from ida_mcp.exceptions import IDAError
+from ida_mcp.exceptions import IDAError, slice_sidecar_stem
 from ida_mcp.transforms import MANAGEMENT_TOOLS
 
 log = logging.getLogger(__name__)
@@ -161,22 +161,24 @@ def extract_db_prefix(uri: str) -> tuple[str | None, str]:
     return database_id, worker_uri
 
 
-def _canonical_path(path: str) -> str:
+def _canonical_path(path: str, fat_arch: str = "") -> str:
     """Canonical key for a database: the resolved ``.i64`` path.
 
     Accepts a raw binary path or an existing ``.i64``/``.idb`` path.
     Always resolves to the ``.i64`` so that either input maps to the
-    same worker.
+    same worker.  Uses ``realpath`` (not just ``abspath``) so two
+    symlinks pointing at the same file dedup to the same worker.
+
+    When *fat_arch* is set, the key includes the slice suffix so
+    different architectures of the same universal binary dedup to
+    separate workers (and per-slice sidecar paths).  Explicit
+    ``.i64``/``.idb`` inputs ignore *fat_arch* — the stored database
+    already pins a specific slice.
     """
     resolved = os.path.realpath(os.path.expanduser(path))
-    _, ext = os.path.splitext(resolved)
-    if ext.lower() in (".i64", ".idb"):
-        # Normalize .idb → .i64 for consistent keying.
-        resolved = os.path.splitext(resolved)[0] + ".i64"
-    else:
-        # Binary path — the database lives alongside it.
-        resolved = resolved + ".i64"
-    return resolved
+    # slice_sidecar_stem gives us ``<binary>`` or ``<binary>.<slice>``
+    # (or ``<db>`` for an explicit .i64/.idb); append .i64 for the key.
+    return slice_sidecar_stem(resolved, fat_arch) + ".i64"
 
 
 def _normalize_id(stem: str) -> str:
@@ -1014,19 +1016,25 @@ class WorkerPoolProvider(Provider):
         processor: str = "",
         loader: str = "",
         base_address: str = "",
+        fat_arch: str = "",
         options: str = "",
     ) -> dict[str, Any]:
         """Spawn a worker subprocess and open a database in it."""
         # Resolve the real path but keep the original extension so the worker
         # can distinguish "raw binary" from "existing .i64/.idb database".
         # _canonical_path always normalises to .i64 for dedup keying only.
+        # When fat_arch is set the key is slice-specific so different
+        # architectures of the same universal binary each get their own
+        # worker (and, downstream in session.open, their own sidecar file).
         resolved = os.path.realpath(os.path.expanduser(file_path))
-        canonical = _canonical_path(file_path)
+        canonical = _canonical_path(file_path, fat_arch)
         log.debug(
-            "spawn_worker: file_path=%s resolved=%s canonical=%s db_id=%s session=%s force_new=%s",
+            "spawn_worker: file_path=%s resolved=%s canonical=%s fat_arch=%s "
+            "db_id=%s session=%s force_new=%s",
             file_path,
             resolved,
             canonical,
+            fat_arch or "(none)",
             database_id or "(auto)",
             session_id,
             force_new,
@@ -1115,6 +1123,7 @@ class WorkerPoolProvider(Provider):
                 processor=processor,
                 loader=loader,
                 base_address=base_address,
+                fat_arch=fat_arch,
                 options=options,
             ),
             name=f"background-spawn-{db_id}",
@@ -1141,6 +1150,7 @@ class WorkerPoolProvider(Provider):
         processor: str = "",
         loader: str = "",
         base_address: str = "",
+        fat_arch: str = "",
         options: str = "",
     ) -> None:
         """Spawn a worker subprocess and open the database in the background.
@@ -1200,6 +1210,8 @@ class WorkerPoolProvider(Provider):
                 open_args["loader"] = loader
             if base_address:
                 open_args["base_address"] = base_address
+            if fat_arch:
+                open_args["fat_arch"] = fat_arch
             if options:
                 open_args["options"] = options
             result = await client.call_tool_mcp("open_database", open_args)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -25,6 +25,8 @@ from ida_mcp.exceptions import (
     check_fat_binary,
     check_processor_ambiguity,
     detect_fat_slices,
+    reject_fat_arch_on_database,
+    reject_force_new_on_database,
     slice_sidecar_stem,
 )
 
@@ -479,6 +481,11 @@ def test_check_fat_binary_symlink_to_idb_with_fat_arch_raises(tmp_path):
     ``fat_arch=arm64`` would slip past the fail-fast check and only error
     later inside the worker.  ``check_fat_binary`` resolves the symlink
     up front so the extension-based guard sees the real target.
+
+    The error message must quote the user's **original** path (the
+    symlink), not the resolved realpath, so the user sees what they
+    typed — consistency with the other errors raised from
+    :func:`check_fat_binary`.
     """
     db = tmp_path / "thing.i64"
     db.write_bytes(b"\x00")
@@ -489,6 +496,10 @@ def test_check_fat_binary_symlink_to_idb_with_fat_arch_raises(tmp_path):
     payload = json.loads(str(exc.value))
     assert payload["error_type"] == "InvalidArgument"
     assert "existing IDA database" in payload["error"]
+    # The error text should name the symlink the user typed, not the
+    # resolved realpath target.
+    assert str(link) in payload["error"]
+    assert str(db) not in payload["error"]
 
 
 def test_check_fat_binary_symlink_to_idb_without_fat_arch_short_circuits(tmp_path):
@@ -576,6 +587,149 @@ def test_check_fat_binary_thin_file_with_fat_arch_raises(tmp_path):
     payload = json.loads(str(exc.value))
     assert payload["error_type"] == "InvalidArgument"
     assert "is not a Mach-O fat" in payload["error"]
+
+
+# reject_fat_arch_on_database ----------------------------------------------
+
+
+def test_reject_fat_arch_on_database_idb_path(tmp_path):
+    """Direct .i64/.idb input + fat_arch raises InvalidArgument."""
+    db = tmp_path / "thing.i64"
+    db.write_bytes(b"\x00")
+    with pytest.raises(IDAError, match="InvalidArgument") as exc:
+        reject_fat_arch_on_database(str(db), "arm64")
+    payload = json.loads(str(exc.value))
+    assert payload["error_type"] == "InvalidArgument"
+    assert "existing IDA database" in payload["error"]
+    assert str(db) in payload["error"]
+
+
+def test_reject_fat_arch_on_database_no_fat_arch_is_noop(tmp_path):
+    """Empty fat_arch is a no-op regardless of path type."""
+    db = tmp_path / "thing.i64"
+    db.write_bytes(b"\x00")
+    reject_fat_arch_on_database(str(db), "")
+    reject_fat_arch_on_database(str(tmp_path / "firmware.bin"), "")
+
+
+def test_reject_fat_arch_on_database_raw_binary_is_noop(tmp_path):
+    """Raw binaries are never rejected — the guard only fires on .i64/.idb."""
+    raw = tmp_path / "firmware.bin"
+    raw.write_bytes(b"\x00" * 64)
+    reject_fat_arch_on_database(str(raw), "arm64")
+
+
+def test_reject_fat_arch_on_database_symlink_without_extension(tmp_path):
+    """A symlink-without-extension pointing at an ``.i64`` is caught.
+
+    The function realpath's internally so the extension-based guard
+    sees the real target.  Without this, a symlink name like
+    ``./shortcut`` → ``real.i64`` combined with ``fat_arch=arm64``
+    would slip past the guard entirely.
+    """
+    db = tmp_path / "real.i64"
+    db.write_bytes(b"\x00")
+    link = tmp_path / "shortcut"
+    link.symlink_to(db)
+    with pytest.raises(IDAError, match="InvalidArgument") as exc:
+        reject_fat_arch_on_database(str(link), "arm64")
+    payload = json.loads(str(exc.value))
+    # The user's original path (the symlink) appears in the error
+    # message, not the resolved target.
+    assert str(link) in payload["error"]
+    assert str(db) not in payload["error"]
+
+
+# reject_force_new_on_database ----------------------------------------------
+
+
+def test_reject_force_new_on_database_idb_path(tmp_path):
+    """force_new=True combined with an .i64 path is rejected.
+
+    Without this check, :meth:`Session.open` would strip the extension,
+    delete the database files, and then try to open the (possibly
+    missing) binary at the stem path — destroying the user's stored
+    analysis with nothing to recover to.
+    """
+    db = tmp_path / "thing.i64"
+    db.write_bytes(b"\x00")
+    with pytest.raises(IDAError, match="InvalidArgument") as exc:
+        reject_force_new_on_database(str(db), force_new=True)
+    payload = json.loads(str(exc.value))
+    assert payload["error_type"] == "InvalidArgument"
+    assert "force_new" in payload["error"]
+    assert str(db) in payload["error"]
+
+
+def test_reject_force_new_on_database_idb_extension(tmp_path):
+    """Both .i64 and .idb extensions are rejected."""
+    db = tmp_path / "thing.idb"
+    db.write_bytes(b"\x00")
+    with pytest.raises(IDAError, match="InvalidArgument"):
+        reject_force_new_on_database(str(db), force_new=True)
+
+
+def test_reject_force_new_on_database_raw_binary_is_noop(tmp_path):
+    """Raw binaries + force_new is the legitimate use — must not raise."""
+    raw = tmp_path / "firmware.bin"
+    raw.write_bytes(b"\x00" * 64)
+    reject_force_new_on_database(str(raw), force_new=True)
+
+
+def test_reject_force_new_on_database_force_new_false_is_noop(tmp_path):
+    """force_new=False is always a no-op, even on .i64 paths."""
+    db = tmp_path / "thing.i64"
+    db.write_bytes(b"\x00")
+    reject_force_new_on_database(str(db), force_new=False)
+
+
+def test_reject_force_new_on_database_symlink_without_extension(tmp_path):
+    """A symlink-without-extension pointing at an ``.i64`` is caught.
+
+    Same realpath trick as :func:`reject_fat_arch_on_database`:
+    without resolving, a symlink name like ``./shortcut`` →
+    ``real.i64`` combined with ``force_new=True`` would slip past
+    the extension guard and reach :meth:`Session.open`, which would
+    then delete the stored database before discovering the binary
+    is missing.
+    """
+    db = tmp_path / "real.i64"
+    db.write_bytes(b"\x00")
+    link = tmp_path / "shortcut"
+    link.symlink_to(db)
+    with pytest.raises(IDAError, match="InvalidArgument") as exc:
+        reject_force_new_on_database(str(link), force_new=True)
+    payload = json.loads(str(exc.value))
+    assert str(link) in payload["error"]
+    assert str(db) not in payload["error"]
+
+
+def test_check_fat_binary_force_new_with_database_path_rejected(tmp_path):
+    """check_fat_binary must reject force_new=True on an .i64 path up front.
+
+    Fail-fast integration check: the same user error should be caught
+    at the supervisor level (via check_fat_binary) without needing to
+    reach :meth:`Session.open`.
+    """
+    db = tmp_path / "thing.i64"
+    db.write_bytes(b"\x00")
+    with pytest.raises(IDAError, match="InvalidArgument") as exc:
+        check_fat_binary(str(db), fat_arch="", force_new=True)
+    payload = json.loads(str(exc.value))
+    assert "force_new" in payload["error"]
+
+
+def test_check_fat_binary_force_new_on_symlink_to_idb_rejected(tmp_path):
+    """Same as above, through a symlink-without-extension."""
+    db = tmp_path / "real.i64"
+    db.write_bytes(b"\x00")
+    link = tmp_path / "shortcut"
+    link.symlink_to(db)
+    with pytest.raises(IDAError, match="InvalidArgument") as exc:
+        check_fat_binary(str(link), fat_arch="", force_new=True)
+    payload = json.loads(str(exc.value))
+    assert "force_new" in payload["error"]
+    assert str(link) in payload["error"]
 
 
 # slice_sidecar_stem --------------------------------------------------------

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,13 +4,15 @@
 
 """Unit tests for exceptions.py — processor ambiguity detection and IDAError.
 
-These tests cover check_processor_ambiguity and PRIMARY_IDB_EXTENSIONS —
-all functions that can run without idalib.
+These tests cover check_processor_ambiguity, check_fat_binary,
+detect_fat_slices and PRIMARY_IDB_EXTENSIONS — all functions that can
+run without idalib.
 """
 
 from __future__ import annotations
 
 import json
+import struct
 
 import pytest
 
@@ -18,7 +20,10 @@ from ida_mcp.exceptions import (
     AMBIGUOUS_PROCESSORS,
     IDAError,
     build_ida_args,
+    check_fat_binary,
     check_processor_ambiguity,
+    detect_fat_slices,
+    slice_sidecar_stem,
 )
 
 # ---------------------------------------------------------------------------
@@ -90,6 +95,20 @@ def test_existing_sidecar_skips_check(tmp_path):
     sidecar = tmp_path / "firmware.bin.i64"
     sidecar.write_bytes(b"\x00")
     check_processor_ambiguity("arm", str(raw), force_new=False)
+
+
+def test_processor_ambiguity_uses_slice_specific_sidecar(tmp_path):
+    """fat_arch routes the stored-analysis short-circuit to the per-slice sidecar."""
+    raw = tmp_path / "universal"
+    raw.write_bytes(b"\x00" * 16)
+    # Default sidecar doesn't exist, but a slice-specific one does.
+    (tmp_path / "universal.arm64.i64").write_bytes(b"\x00")
+    # With fat_arch="arm64", the slice sidecar suppresses the check —
+    # stored analysis pins everything including the processor.
+    check_processor_ambiguity("arm", str(raw), force_new=False, fat_arch="arm64")
+    # Without fat_arch, there's no default sidecar — the check fires.
+    with pytest.raises(IDAError, match="AmbiguousProcessor"):
+        check_processor_ambiguity("arm", str(raw), force_new=False)
 
 
 def test_unambiguous_processor(tmp_path):
@@ -220,3 +239,283 @@ def test_build_ida_args_no_false_positive_on_longer_flags():
     result = build_ida_args(processor="arm:ARMv7-M", options="--prefer-something")
     assert "-parm:ARMv7-M" in result
     assert "--prefer-something" in result
+
+
+# ---------------------------------------------------------------------------
+# Fat Mach-O detection + validation
+# ---------------------------------------------------------------------------
+
+# Mach-O cputype constants (from /usr/include/mach/machine.h).
+_CPUTYPE_X86_64 = 0x01000007
+_CPUTYPE_ARM64 = 0x0100000C
+_CPUTYPE_ARM = 12
+_CPU_SUBTYPE_ARM_V7 = 9
+_CPU_SUBTYPE_ARM64_E = 2
+
+
+def _write_fat_header(
+    path,
+    slices: list[tuple[int, int]],
+    *,
+    magic: int = 0xCAFEBABE,
+) -> None:
+    """Write a minimal fat Mach-O header (no slice payloads) to *path*.
+
+    *slices* is a list of (cputype, cpusubtype) tuples.
+    """
+    data = bytearray(struct.pack(">II", magic, len(slices)))
+    for cputype, cpusubtype in slices:
+        if magic == 0xCAFEBABE:
+            # cputype, cpusubtype, offset, size, align
+            data += struct.pack(">IIIII", cputype, cpusubtype, 0x1000, 0x1000, 12)
+        else:
+            # cputype, cpusubtype, offset (u64), size (u64), align, reserved
+            data += struct.pack(">IIQQII", cputype, cpusubtype, 0x1000, 0x1000, 12, 0)
+    path.write_bytes(bytes(data))
+
+
+# detect_fat_slices ---------------------------------------------------------
+
+
+def test_detect_fat_slices_fat_magic_32(tmp_path):
+    fat = tmp_path / "universal"
+    _write_fat_header(fat, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)])
+    assert detect_fat_slices(str(fat)) == ["x86_64", "arm64"]
+
+
+def test_detect_fat_slices_fat_magic_64(tmp_path):
+    fat = tmp_path / "universal64"
+    _write_fat_header(fat, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)], magic=0xCAFEBABF)
+    assert detect_fat_slices(str(fat)) == ["x86_64", "arm64"]
+
+
+def test_detect_fat_slices_arm_subtype_refinement(tmp_path):
+    """arm64e and armv7 should surface via cpusubtype refinement."""
+    fat = tmp_path / "refined"
+    _write_fat_header(
+        fat,
+        [
+            (_CPUTYPE_ARM64, _CPU_SUBTYPE_ARM64_E),
+            (_CPUTYPE_ARM, _CPU_SUBTYPE_ARM_V7),
+        ],
+    )
+    assert detect_fat_slices(str(fat)) == ["arm64e", "armv7"]
+
+
+def test_detect_fat_slices_thin_file(tmp_path):
+    """A non-fat file returns None."""
+    thin = tmp_path / "thin.bin"
+    thin.write_bytes(b"\x00" * 64)
+    assert detect_fat_slices(str(thin)) is None
+
+
+def test_detect_fat_slices_java_class_file(tmp_path):
+    """Java .class files share CAFEBABE magic but have a huge nfat_arch.
+
+    The parser must reject them — either via the 32-slice sanity cap or
+    because their "cpu type" field doesn't match any known Mach-O arch.
+    """
+    java = tmp_path / "Foo.class"
+    # CAFEBABE + minor(0) << 16 | major(65) → typical Java class header.
+    # nfat_arch reads as 0x00000041 = 65 → caught by _MAX_FAT_SLICES cap.
+    java.write_bytes(bytes.fromhex("cafebabe00000041") + b"\x00" * 32)
+    assert detect_fat_slices(str(java)) is None
+
+
+def test_detect_fat_slices_nonexistent_path(tmp_path):
+    """Missing file → None, no exception."""
+    assert detect_fat_slices(str(tmp_path / "does_not_exist")) is None
+
+
+def test_detect_fat_slices_unknown_cputype_rejected(tmp_path):
+    """Valid fat header but with a nonsense cputype is treated as not-fat."""
+    fat = tmp_path / "weird"
+    # 0x99 is not a valid Mach-O base cputype.
+    _write_fat_header(fat, [(0x99, 0)])
+    assert detect_fat_slices(str(fat)) is None
+
+
+def test_detect_fat_slices_truncated(tmp_path):
+    """Header claims 2 slices but the file only contains 1 — return None."""
+    fat = tmp_path / "truncated"
+    # nfat_arch=2 but only one entry's worth of data follows.
+    data = struct.pack(">II", 0xCAFEBABE, 2)
+    data += struct.pack(">IIIII", _CPUTYPE_X86_64, 3, 0x1000, 0x1000, 12)
+    fat.write_bytes(data)
+    assert detect_fat_slices(str(fat)) is None
+
+
+# check_fat_binary ----------------------------------------------------------
+
+
+def test_check_fat_binary_ambiguous(tmp_path):
+    fat = tmp_path / "universal"
+    _write_fat_header(fat, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)])
+    with pytest.raises(IDAError, match="AmbiguousFatBinary") as exc:
+        check_fat_binary(str(fat), fat_arch="", force_new=False)
+    payload = json.loads(str(exc.value))
+    assert payload["error_type"] == "AmbiguousFatBinary"
+    assert payload["available"] == ["x86_64", "arm64"]
+
+
+def test_check_fat_binary_valid_arch_returns_index(tmp_path):
+    """A valid fat_arch returns its 1-based slice index."""
+    fat = tmp_path / "universal"
+    _write_fat_header(
+        fat,
+        [
+            (_CPUTYPE_X86_64, 3),
+            (_CPUTYPE_ARM64, 0),
+            (_CPUTYPE_ARM64, _CPU_SUBTYPE_ARM64_E),
+        ],
+    )
+    # Slice index is 1-based, in on-disk header order — IDA's -T flag
+    # references slices by this index.
+    assert check_fat_binary(str(fat), fat_arch="x86_64", force_new=False) == 1
+    assert check_fat_binary(str(fat), fat_arch="arm64", force_new=False) == 2
+    assert check_fat_binary(str(fat), fat_arch="arm64e", force_new=False) == 3
+
+
+def test_check_fat_binary_unknown_arch(tmp_path):
+    fat = tmp_path / "universal"
+    _write_fat_header(fat, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)])
+    with pytest.raises(IDAError, match="UnknownFatArch") as exc:
+        check_fat_binary(str(fat), fat_arch="mips", force_new=False)
+    payload = json.loads(str(exc.value))
+    assert payload["error_type"] == "UnknownFatArch"
+    assert payload["available"] == ["x86_64", "arm64"]
+
+
+def test_check_fat_binary_idb_short_circuits(tmp_path):
+    """Opening an existing .i64 database returns None (no -T flag needed)."""
+    db = tmp_path / "thing.i64"
+    # Intentionally write a valid fat header to the .i64 — the check
+    # should still return None because the extension takes precedence
+    # (IDA reuses the stored slice).
+    _write_fat_header(db, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)])
+    assert check_fat_binary(str(db), fat_arch="", force_new=False) is None
+
+
+def test_check_fat_binary_slice_specific_sidecar_short_circuits(tmp_path):
+    """A per-slice sidecar (foo.arm64.i64) short-circuits the check for that slice."""
+    fat = tmp_path / "universal"
+    _write_fat_header(fat, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)])
+    # Stored analysis for the arm64 slice lives at the suffixed path
+    # so other slices remain distinct on disk.
+    (tmp_path / "universal.arm64.i64").write_bytes(b"\x00")
+    # arm64 short-circuits — stored analysis pins the slice.
+    assert check_fat_binary(str(fat), fat_arch="arm64", force_new=False) is None
+    # x86_64 does NOT short-circuit — different slice, different sidecar.
+    assert check_fat_binary(str(fat), fat_arch="x86_64", force_new=False) == 1
+
+
+def test_check_fat_binary_default_sidecar_does_not_short_circuit_slice_open(tmp_path):
+    """A default sidecar (foo.i64) must not hide a slice-specific check."""
+    fat = tmp_path / "universal"
+    _write_fat_header(fat, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)])
+    # Default sidecar exists — it represents a prior open of the default
+    # (slice 1) analysis.  A new call with fat_arch="arm64" must
+    # recognize that no arm64-specific sidecar exists yet and return
+    # the arm64 slice index so session.open can create one.
+    (tmp_path / "universal.i64").write_bytes(b"\x00")
+    assert check_fat_binary(str(fat), fat_arch="arm64", force_new=False) == 2
+
+
+def test_check_fat_binary_default_sidecar_short_circuits_default_open(tmp_path):
+    """Opening a fat binary without fat_arch reuses the default sidecar."""
+    fat = tmp_path / "universal"
+    _write_fat_header(fat, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)])
+    (tmp_path / "universal.i64").write_bytes(b"\x00")
+    # No fat_arch + default sidecar exists → None (reuse).
+    assert check_fat_binary(str(fat), fat_arch="", force_new=False) is None
+
+
+def test_check_fat_binary_force_new_still_checks(tmp_path):
+    """force_new=True should still fail-fast on a fat binary."""
+    fat = tmp_path / "universal"
+    _write_fat_header(fat, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)])
+    (tmp_path / "universal.i64").write_bytes(b"\x00")
+    with pytest.raises(IDAError, match="AmbiguousFatBinary"):
+        check_fat_binary(str(fat), fat_arch="", force_new=True)
+
+
+def test_check_fat_binary_force_new_on_slice_with_sidecar(tmp_path):
+    """force_new=True ignores a slice-specific sidecar and re-validates."""
+    fat = tmp_path / "universal"
+    _write_fat_header(fat, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)])
+    (tmp_path / "universal.arm64.i64").write_bytes(b"\x00")
+    # Even though the sidecar exists, force_new forces re-parsing and
+    # returns the slice index so session.open creates it fresh.
+    assert check_fat_binary(str(fat), fat_arch="arm64", force_new=True) == 2
+
+
+def test_check_fat_binary_thin_file_noop(tmp_path):
+    """Thin (non-fat) files are left alone even if fat_arch is set."""
+    thin = tmp_path / "thin.bin"
+    thin.write_bytes(b"\x00" * 64)
+    # None — detect_fat_slices returns None, so check_fat_binary
+    # treats the file as unknown and defers to IDA.
+    assert check_fat_binary(str(thin), fat_arch="", force_new=False) is None
+    assert check_fat_binary(str(thin), fat_arch="arm64", force_new=False) is None
+
+
+# slice_sidecar_stem --------------------------------------------------------
+
+
+def test_slice_sidecar_stem_default(tmp_path):
+    """Without fat_arch, the stem is the absolute binary path."""
+    raw = tmp_path / "firmware.bin"
+    assert slice_sidecar_stem(str(raw)) == str(raw)
+
+
+def test_slice_sidecar_stem_with_fat_arch(tmp_path):
+    """With fat_arch, the stem gets a slice suffix for per-slice sidecars."""
+    raw = tmp_path / "universal"
+    assert slice_sidecar_stem(str(raw), "arm64") == f"{raw}.arm64"
+
+
+def test_slice_sidecar_stem_idb_path_ignores_fat_arch(tmp_path):
+    """An .i64 / .idb input pins a slice — fat_arch is dropped and the
+    stem is the path with the extension stripped."""
+    db = tmp_path / "universal.arm64.i64"
+    expected = str(tmp_path / "universal.arm64")
+    assert slice_sidecar_stem(str(db)) == expected
+    assert slice_sidecar_stem(str(db), fat_arch="x86_64") == expected
+
+
+# build_ida_args + fat_slice_index ------------------------------------------
+
+
+def test_build_ida_args_fat_slice_index_emits_fat_macho_loader():
+    """fat_slice_index emits -T"Fat Mach-O file, <N>" — IDA's only
+    documented way to pick a slice in headless mode."""
+    assert build_ida_args(fat_slice_index=2) == '-T"Fat Mach-O file, 2"'
+
+
+def test_build_ida_args_fat_slice_index_rejects_explicit_loader():
+    """loader and fat_slice_index both map to -T — reject the combination."""
+    with pytest.raises(IDAError, match="loader and fat_arch"):
+        build_ida_args(loader="Binary file", fat_slice_index=2)
+
+
+def test_build_ida_args_fat_slice_index_combined():
+    """fat_slice_index composes with processor and base_address in the usual order."""
+    # processor is typically auto-detected for Mach-O, but pinning it
+    # shouldn't conflict with the fat loader selection.
+    result = build_ida_args(
+        processor="arm:ARMv8-A",
+        fat_slice_index=2,
+        base_address="0x100000000",
+    )
+    assert result == '-parm:ARMv8-A -T"Fat Mach-O file, 2" -b0x10000000'
+
+
+def test_build_ida_args_fat_slice_index_rejects_t_in_options():
+    """Even without an explicit loader, -T in options conflicts with fat_slice_index."""
+    with pytest.raises(IDAError, match="loader"):
+        build_ida_args(fat_slice_index=2, options="-TELF")
+
+
+def test_build_ida_args_fat_slice_index_large_number():
+    """Large fat indices (up to the 32-slice cap) format correctly."""
+    assert build_ida_args(fat_slice_index=10) == '-T"Fat Mach-O file, 10"'

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -450,13 +450,28 @@ def test_check_fat_binary_force_new_on_slice_with_sidecar(tmp_path):
 
 
 def test_check_fat_binary_thin_file_noop(tmp_path):
-    """Thin (non-fat) files are left alone even if fat_arch is set."""
+    """Thin (non-fat) files return None when no fat_arch is requested
+    — check_fat_binary is a no-op for ELF, PE, and raw binaries."""
     thin = tmp_path / "thin.bin"
     thin.write_bytes(b"\x00" * 64)
-    # None — detect_fat_slices returns None, so check_fat_binary
-    # treats the file as unknown and defers to IDA.
     assert check_fat_binary(str(thin), fat_arch="", force_new=False) is None
-    assert check_fat_binary(str(thin), fat_arch="arm64", force_new=False) is None
+
+
+def test_check_fat_binary_thin_file_with_fat_arch_raises(tmp_path):
+    """fat_arch set on a non-fat file raises InvalidArgument.
+
+    Silently ignoring would let a typo (``fat_arch="arm64"`` on an ELF,
+    or on a raw firmware blob) slip through and produce a confusingly
+    suffixed sidecar on disk.  Surfacing the error makes the mistake
+    immediate.
+    """
+    thin = tmp_path / "thin.bin"
+    thin.write_bytes(b"\x00" * 64)
+    with pytest.raises(IDAError, match="InvalidArgument") as exc:
+        check_fat_binary(str(thin), fat_arch="arm64", force_new=False)
+    payload = json.loads(str(exc.value))
+    assert payload["error_type"] == "InvalidArgument"
+    assert "is not a Mach-O fat" in payload["error"]
 
 
 # slice_sidecar_stem --------------------------------------------------------

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -20,6 +20,7 @@ import pytest
 from ida_mcp.exceptions import (
     AMBIGUOUS_PROCESSORS,
     IDAError,
+    append_output_flag,
     build_ida_args,
     check_fat_binary,
     check_processor_ambiguity,
@@ -387,6 +388,55 @@ def test_check_fat_binary_unknown_arch(tmp_path):
     assert payload["available"] == ["x86_64", "arm64"]
 
 
+def test_check_fat_binary_rejects_duplicate_slice_names(tmp_path):
+    """Two slices that resolve to the same lipo-style name are rejected.
+
+    Hand-crafted header with two arm64 entries (different cpusubtypes that
+    both collapse to ``arm64``).  ``slices.index(fat_arch)`` would silently
+    pick the first match and hand IDA an index the user may not have
+    intended, so ``check_fat_binary`` raises ``DuplicateFatSlice`` up front
+    instead.  No ``lipo``-produced file hits this case, but malformed or
+    hand-crafted fat headers can.
+    """
+    fat = tmp_path / "weird"
+    # Two ARM64 entries with subtypes that are NOT in _CPU_SUBTYPE_NAMES
+    # (so both fall through to the bare "arm64" name).  Subtype 0 is
+    # ALL, subtype 100 is unknown — neither matches ARM64E (2).
+    _write_fat_header(fat, [(_CPUTYPE_ARM64, 0), (_CPUTYPE_ARM64, 100)])
+    # The check must fail regardless of whether fat_arch is set — the
+    # file is structurally ambiguous and unusable either way.
+    with pytest.raises(IDAError, match="DuplicateFatSlice") as exc:
+        check_fat_binary(str(fat), fat_arch="arm64", force_new=False)
+    payload = json.loads(str(exc.value))
+    assert payload["error_type"] == "DuplicateFatSlice"
+    assert payload["available"] == ["arm64", "arm64"]
+    assert payload["duplicates"] == ["arm64"]
+
+    with pytest.raises(IDAError, match="DuplicateFatSlice"):
+        check_fat_binary(str(fat), fat_arch="", force_new=False)
+
+
+def test_check_fat_binary_reports_each_duplicate_once(tmp_path):
+    """Multiple distinct duplicates are listed once each, not repeated."""
+    fat = tmp_path / "weirder"
+    # Three arm64 entries — the duplicate list should contain ``arm64``
+    # once, not twice.
+    _write_fat_header(
+        fat,
+        [
+            (_CPUTYPE_ARM64, 0),
+            (_CPUTYPE_ARM64, 100),
+            (_CPUTYPE_ARM64, 101),
+            (_CPUTYPE_X86_64, 3),
+        ],
+    )
+    with pytest.raises(IDAError, match="DuplicateFatSlice") as exc:
+        check_fat_binary(str(fat), fat_arch="arm64", force_new=False)
+    payload = json.loads(str(exc.value))
+    assert payload["duplicates"] == ["arm64"]
+    assert payload["available"] == ["arm64", "arm64", "arm64", "x86_64"]
+
+
 def test_check_fat_binary_idb_short_circuits(tmp_path):
     """Opening an existing .i64 database returns None (no -T flag needed)."""
     db = tmp_path / "thing.i64"
@@ -395,6 +445,59 @@ def test_check_fat_binary_idb_short_circuits(tmp_path):
     # (IDA reuses the stored slice).
     _write_fat_header(db, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)])
     assert check_fat_binary(str(db), fat_arch="", force_new=False) is None
+
+
+def test_check_fat_binary_idb_with_fat_arch_raises(tmp_path):
+    """Passing fat_arch alongside an explicit .i64/.idb path is rejected.
+
+    The stored database already pins a slice — accepting fat_arch would
+    either be contradictory (stored analysis for a different slice) or
+    redundant (same slice).  Fail fast with InvalidArgument so the user
+    cannot expect a slice swap that is not going to happen.
+    """
+    db = tmp_path / "thing.i64"
+    _write_fat_header(db, [(_CPUTYPE_X86_64, 3), (_CPUTYPE_ARM64, 0)])
+    with pytest.raises(IDAError, match="InvalidArgument") as exc:
+        check_fat_binary(str(db), fat_arch="arm64", force_new=False)
+    payload = json.loads(str(exc.value))
+    assert payload["error_type"] == "InvalidArgument"
+    assert "existing IDA database" in payload["error"]
+
+    # Same for .idb extension.
+    db_idb = tmp_path / "thing.idb"
+    db_idb.write_bytes(b"\x00")
+    with pytest.raises(IDAError, match="InvalidArgument"):
+        check_fat_binary(str(db_idb), fat_arch="x86_64", force_new=False)
+
+
+def test_check_fat_binary_symlink_to_idb_with_fat_arch_raises(tmp_path):
+    """A symlink-without-extension pointing at an ``.i64`` is still rejected.
+
+    Fail-fast parity with :meth:`session.Session.open`: the supervisor
+    path must catch the same mistake that session.open does, otherwise a
+    symlink name like ``./shortcut`` → ``real.i64`` combined with
+    ``fat_arch=arm64`` would slip past the fail-fast check and only error
+    later inside the worker.  ``check_fat_binary`` resolves the symlink
+    up front so the extension-based guard sees the real target.
+    """
+    db = tmp_path / "thing.i64"
+    db.write_bytes(b"\x00")
+    link = tmp_path / "shortcut"  # No extension — extension guard would miss
+    link.symlink_to(db)
+    with pytest.raises(IDAError, match="InvalidArgument") as exc:
+        check_fat_binary(str(link), fat_arch="arm64", force_new=False)
+    payload = json.loads(str(exc.value))
+    assert payload["error_type"] == "InvalidArgument"
+    assert "existing IDA database" in payload["error"]
+
+
+def test_check_fat_binary_symlink_to_idb_without_fat_arch_short_circuits(tmp_path):
+    """A symlink-without-extension pointing at an ``.i64`` is treated as stored."""
+    db = tmp_path / "thing.i64"
+    db.write_bytes(b"\x00")
+    link = tmp_path / "shortcut"
+    link.symlink_to(db)
+    assert check_fat_binary(str(link), fat_arch="", force_new=False) is None
 
 
 def test_check_fat_binary_slice_specific_sidecar_short_circuits(tmp_path):
@@ -577,3 +680,55 @@ def test_build_ida_args_dash_o_check_no_false_positive_on_long_option():
     """``--no-output`` contains ``-o`` but the anchor skips it."""
     result = build_ida_args(options="--no-output")
     assert result == "--no-output"
+
+
+# append_output_flag --------------------------------------------------------
+
+
+def test_append_output_flag_none_options():
+    """``None`` options yields just the -o flag."""
+    assert append_output_flag(None, "/tmp/foo.arm64") == "-o/tmp/foo.arm64"
+
+
+def test_append_output_flag_empty_options():
+    """Empty-string options yields just the -o flag."""
+    assert append_output_flag("", "/tmp/foo.arm64") == "-o/tmp/foo.arm64"
+
+
+def test_append_output_flag_all_whitespace_options():
+    """All-whitespace options is treated the same as empty — no double space."""
+    assert append_output_flag("   ", "/tmp/foo.arm64") == "-o/tmp/foo.arm64"
+
+
+def test_append_output_flag_normal_options():
+    """Normal options get a single separator space before the -o flag."""
+    assert append_output_flag("-parm:ARMv8-A", "/tmp/foo.arm64") == "-parm:ARMv8-A -o/tmp/foo.arm64"
+
+
+def test_append_output_flag_strips_trailing_whitespace():
+    """Trailing whitespace in options must not produce a double space.
+
+    Regression guard: concatenating ``'-parm '`` and ``' -o...'`` with a
+    space separator would yield ``'-parm  -o...'``.  Harmless for IDA's
+    parser but ugly in debug logs, and this helper should normalize it.
+    """
+    assert (
+        append_output_flag("-parm:ARMv8-A ", "/tmp/foo.arm64") == "-parm:ARMv8-A -o/tmp/foo.arm64"
+    )
+    # Leading whitespace is stripped too, for symmetry.
+    assert (
+        append_output_flag("   -parm:ARMv8-A   ", "/tmp/foo.arm64")
+        == "-parm:ARMv8-A -o/tmp/foo.arm64"
+    )
+
+
+def test_append_output_flag_quotes_path_with_spaces():
+    """Paths containing spaces are double-quoted via quote_ida_arg."""
+    result = append_output_flag(None, "/tmp/my stem.arm64")
+    assert result == '-o"/tmp/my stem.arm64"'
+
+
+def test_append_output_flag_quotes_path_with_spaces_and_options():
+    """Stem quoting composes correctly with a non-empty options string."""
+    result = append_output_flag("-parm:ARMv8-A", "/tmp/my stem.arm64")
+    assert result == '-parm:ARMv8-A -o"/tmp/my stem.arm64"'

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -12,6 +12,7 @@ run without idalib.
 from __future__ import annotations
 
 import json
+import os
 import struct
 
 import pytest
@@ -478,24 +479,37 @@ def test_check_fat_binary_thin_file_with_fat_arch_raises(tmp_path):
 
 
 def test_slice_sidecar_stem_default(tmp_path):
-    """Without fat_arch, the stem is the absolute binary path."""
+    """Without fat_arch, the stem is the realpath'd binary path."""
     raw = tmp_path / "firmware.bin"
-    assert slice_sidecar_stem(str(raw)) == str(raw)
+    # realpath() because pytest's tmp_path on macOS is under /var -> /private/var.
+    expected = os.path.realpath(str(raw))
+    assert slice_sidecar_stem(str(raw)) == expected
 
 
 def test_slice_sidecar_stem_with_fat_arch(tmp_path):
     """With fat_arch, the stem gets a slice suffix for per-slice sidecars."""
     raw = tmp_path / "universal"
-    assert slice_sidecar_stem(str(raw), "arm64") == f"{raw}.arm64"
+    expected = f"{os.path.realpath(str(raw))}.arm64"
+    assert slice_sidecar_stem(str(raw), "arm64") == expected
 
 
 def test_slice_sidecar_stem_idb_path_ignores_fat_arch(tmp_path):
     """An .i64 / .idb input pins a slice — fat_arch is dropped and the
     stem is the path with the extension stripped."""
     db = tmp_path / "universal.arm64.i64"
-    expected = str(tmp_path / "universal.arm64")
+    expected = os.path.splitext(os.path.realpath(str(db)))[0]
     assert slice_sidecar_stem(str(db)) == expected
     assert slice_sidecar_stem(str(db), fat_arch="x86_64") == expected
+
+
+def test_slice_sidecar_stem_resolves_symlink(tmp_path):
+    """Symlinks collapse to the real file — matches _canonical_path dedup."""
+    real = tmp_path / "real_binary"
+    real.write_bytes(b"\x00")
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    assert slice_sidecar_stem(str(link)) == slice_sidecar_stem(str(real))
+    assert slice_sidecar_stem(str(link), "arm64") == slice_sidecar_stem(str(real), "arm64")
 
 
 # build_ida_args + fat_slice_index ------------------------------------------
@@ -522,6 +536,7 @@ def test_build_ida_args_fat_slice_index_combined():
         fat_slice_index=2,
         base_address="0x100000000",
     )
+    # -b emits in paragraphs (addr >> 4), so 0x100000000 → 0x10000000.
     assert result == '-parm:ARMv8-A -T"Fat Mach-O file, 2" -b0x10000000'
 
 
@@ -534,3 +549,31 @@ def test_build_ida_args_fat_slice_index_rejects_t_in_options():
 def test_build_ida_args_fat_slice_index_large_number():
     """Large fat indices (up to the 32-slice cap) format correctly."""
     assert build_ida_args(fat_slice_index=10) == '-T"Fat Mach-O file, 10"'
+
+
+# build_ida_args — -o is reserved for Session.open's sidecar redirection
+# -----------------------------------------------------------------------
+
+
+def test_build_ida_args_rejects_dash_o_in_options():
+    """``-o`` is reserved for Session.open's sidecar redirection."""
+    with pytest.raises(IDAError, match="-o"):
+        build_ida_args(options="-omycustom.i64")
+
+
+def test_build_ida_args_rejects_dash_o_after_whitespace():
+    """``-o`` is caught even when preceded by another flag."""
+    with pytest.raises(IDAError, match="-o"):
+        build_ida_args(options="--some-other-flag -omycustom.i64")
+
+
+def test_build_ida_args_rejects_dash_o_with_fat_slice_index():
+    """The -o reject fires before Session.open appends its own -o<stem>."""
+    with pytest.raises(IDAError, match="-o"):
+        build_ida_args(fat_slice_index=2, options="-osomewhere")
+
+
+def test_build_ida_args_dash_o_check_no_false_positive_on_long_option():
+    """``--no-output`` contains ``-o`` but the anchor skips it."""
+    result = build_ida_args(options="--no-output")
+    assert result == "--no-output"

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -127,6 +127,138 @@ return list(results)
 
 
 # ---------------------------------------------------------------------------
+# Argument unpacking — regression tests for ``_apply_`` guard
+# ---------------------------------------------------------------------------
+
+
+def test_star_args_call(sandbox):
+    """``f(*args)`` — rewritten by RestrictedPython to ``_apply_(f, *args)``."""
+    code = """\
+def add(a, b, c):
+    return a + b + c
+args = [1, 2, 3]
+return add(*args)
+"""
+    assert asyncio.run(sandbox.run(code)) == 6
+
+
+def test_double_star_kwargs_call(sandbox):
+    """``f(**kwargs)`` — rewritten by RestrictedPython to ``_apply_(f, **kwargs)``."""
+    code = """\
+def greet(greeting, name):
+    return greeting + ", " + name
+kw = {"greeting": "hello", "name": "world"}
+return greet(**kw)
+"""
+    assert asyncio.run(sandbox.run(code)) == "hello, world"
+
+
+def test_asyncio_gather_with_star_unpack(sandbox):
+    """``asyncio.gather(*tasks)`` — the real-world pattern that triggered the bug."""
+
+    async def double(x):
+        return x * 2
+
+    code = """\
+import asyncio
+tasks = [double(i) for i in range(4)]
+results = await asyncio.gather(*tasks)
+return list(results)
+"""
+    result = asyncio.run(sandbox.run(code, external_functions={"double": double}))
+    assert result == [0, 2, 4, 6]
+
+
+def test_async_for_over_async_generator(sandbox):
+    """``async for`` — regression test; the default ``visit_AsyncFor`` would
+    wrap the iterable with the sync ``iter`` builtin, breaking async iteration."""
+
+    async def agen():
+        for i in range(3):
+            yield i
+
+    code = """\
+total = 0
+async for x in agen():
+    total += x
+return total
+"""
+    result = asyncio.run(sandbox.run(code, external_functions={"agen": agen}))
+    assert result == 3
+
+
+# ---------------------------------------------------------------------------
+# ``print`` — exercises the ``_print_`` / ``PrintCollector`` wiring
+# ---------------------------------------------------------------------------
+
+
+def test_print_and_printed(sandbox):
+    """``print(...)`` is rewritten to ``_print._call_print(...)``; output is
+    collected and available via the magic ``printed`` name."""
+    code = """\
+print("hello")
+print("world")
+return printed
+"""
+    result = asyncio.run(sandbox.run(code))
+    assert result == "hello\nworld\n"
+
+
+# ---------------------------------------------------------------------------
+# Class definitions — exercise the ``__metaclass__`` wiring
+# ---------------------------------------------------------------------------
+
+
+def test_class_definition(sandbox):
+    """``class C: ...`` — transformer rewrites to ``class C(metaclass=__metaclass__)``."""
+    code = """\
+class Point:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+    def sum(self):
+        return self.x + self.y
+p = Point(3, 4)
+return p.sum()
+"""
+    assert asyncio.run(sandbox.run(code)) == 7
+
+
+def test_class_with_inheritance(sandbox):
+    code = """\
+class Base:
+    def greet(self):
+        return "hi from base"
+class Child(Base):
+    pass
+return Child().greet()
+"""
+    assert asyncio.run(sandbox.run(code)) == "hi from base"
+
+
+def test_classmethod_staticmethod_property(sandbox):
+    """``@classmethod``, ``@staticmethod``, and ``@property`` decorators."""
+    code = """\
+class C:
+    counter = 10
+    def __init__(self, x):
+        self.x = x
+    @classmethod
+    def make(cls):
+        return cls(cls.counter)
+    @staticmethod
+    def constant():
+        return 42
+    @property
+    def doubled(self):
+        return self.x * 2
+c = C.make()
+return (c.x, c.doubled, C.constant())
+"""
+    assert asyncio.run(sandbox.run(code)) == (10, 20, 42)
+
+
+# ---------------------------------------------------------------------------
 # Import controls
 # ---------------------------------------------------------------------------
 
@@ -228,6 +360,152 @@ def test_open_blocked(sandbox):
 def test_dunder_access_blocked(sandbox):
     with pytest.raises(SyntaxError, match="invalid attribute name"):
         asyncio.run(sandbox.run("return ().__class__.__bases__"))
+
+
+def test_frame_introspection_blocked_at_compile_time(sandbox):
+    """Dunder access (``__code__``) is rejected at compile time by the
+    dunder rule — the first line of defence against frame / bytecode
+    introspection."""
+    code = """\
+def f():
+    pass
+return f.__code__
+"""
+    with pytest.raises(SyntaxError, match="invalid attribute name"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_frame_introspection_blocked_at_runtime(sandbox):
+    """``INSPECT_ATTRIBUTES`` names (``f_globals``, ``co_code``, ...) do
+    not start with ``_`` so the dunder heuristic misses them.  The
+    sandbox ``getattr`` guard must block them explicitly, otherwise
+    runtime ``getattr(obj, "f_globals")`` would leak a live frame."""
+    # Any INSPECT_ATTRIBUTES name will do — we ask for it via getattr
+    # on a harmless target; the guard should reject the name regardless
+    # of whether the attribute would actually exist on the object.
+    with pytest.raises(AttributeError, match="invalid attribute name"):
+        asyncio.run(sandbox.run('return getattr(0, "f_globals")'))
+
+
+# ---------------------------------------------------------------------------
+# Single-underscore "private" attribute access — allowed (conventional
+# Python idiom on user classes).  Dunders stay blocked.
+# ---------------------------------------------------------------------------
+
+
+def test_single_underscore_attribute_read_write(sandbox):
+    code = """\
+class Box:
+    def __init__(self, v):
+        self._value = v
+    def get(self):
+        return self._value
+b = Box(7)
+b._value = 99
+return b.get()
+"""
+    assert asyncio.run(sandbox.run(code)) == 99
+
+
+def test_single_underscore_not_dunder(sandbox):
+    """``obj._foo`` is allowed; ``obj.__foo`` is still blocked.
+
+    This relaxation only touches attribute access.  Single-underscore
+    *variable* names (``_x = 1``) are still rejected by the upstream
+    ``check_name`` policy — that's a separate restriction and out of
+    scope for this fix.
+    """
+    code = """\
+class C:
+    def __init__(self):
+        self.foo = 1
+        self._bar = 2
+c = C()
+return (c.foo, c._bar)
+"""
+    assert asyncio.run(sandbox.run(code)) == (1, 2)
+
+    with pytest.raises(SyntaxError, match="invalid attribute name"):
+        asyncio.run(sandbox.run("class C: pass\nc = C()\nreturn c.__bar"))
+
+
+def test_getattr_builtin_allows_single_underscore(sandbox):
+    """``getattr(obj, '_priv')`` at runtime matches the AST rule."""
+    code = """\
+class C:
+    def __init__(self):
+        self._priv = 42
+c = C()
+return getattr(c, '_priv')
+"""
+    assert asyncio.run(sandbox.run(code)) == 42
+
+
+def test_getattr_builtin_blocks_dunder(sandbox):
+    code = "return getattr((), '__class__')"
+    with pytest.raises(AttributeError, match="invalid attribute name"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_hasattr_respects_policy(sandbox):
+    code = """\
+class C:
+    def __init__(self):
+        self._priv = 1
+c = C()
+return (hasattr(c, '_priv'), hasattr((), '__class__'))
+"""
+    # _priv is visible; __class__ is hidden by the guard.
+    assert asyncio.run(sandbox.run(code)) == (True, False)
+
+
+# ---------------------------------------------------------------------------
+# Augmented assignment to attribute targets — ``obj.x += y``
+# ---------------------------------------------------------------------------
+
+
+def test_augassign_attribute_on_instance(sandbox):
+    code = """\
+class Counter:
+    def __init__(self):
+        self.n = 0
+c = Counter()
+c.n += 5
+c.n += 3
+return c.n
+"""
+    assert asyncio.run(sandbox.run(code)) == 8
+
+
+def test_augassign_attribute_on_classvar(sandbox):
+    """``cls.count += 1`` inside a classmethod — the original failing pattern."""
+    code = """\
+class Counter:
+    count = 0
+    @classmethod
+    def bump(cls):
+        cls.count += 1
+        return cls.count
+Counter.bump()
+Counter.bump()
+Counter.bump()
+return Counter.count
+"""
+    assert asyncio.run(sandbox.run(code)) == 3
+
+
+def test_augassign_attribute_blocks_dunder(sandbox):
+    """``obj.__dunder__ += y`` stays rejected — augmented assignment
+    must not be an escape hatch around the attribute-name check."""
+    with pytest.raises(SyntaxError, match="invalid attribute name"):
+        asyncio.run(sandbox.run("class C:\n    pass\nc = C()\nc.__x += 1"))
+
+
+def test_augassign_subscript_still_blocked(sandbox):
+    """Augmented subscript assignment (``d[k] += v``) is still rejected
+    — we only relaxed the Attribute case."""
+    with pytest.raises(SyntaxError, match="Augmented assignment"):
+        asyncio.run(sandbox.run("d = {'a': 1}\nd['a'] += 1"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -18,8 +18,10 @@ import pytest
 from ida_mcp.sandbox import (
     _MAX_PRINT_CHARS,
     RestrictedPythonSandbox,
+    _AsyncRestrictingNodeTransformer,
     _BoundedPrintCollector,
     _is_forbidden_attr,
+    _rejected_stmt_placeholder,
 )
 
 
@@ -587,6 +589,57 @@ return boxes[0].n
 """
     with pytest.raises(SyntaxError, match="plain dotted name"):
         asyncio.run(sandbox.run(code))
+
+
+def test_augassign_rejected_attribute_returns_pass_placeholder():
+    """Defense-in-depth: rejected AugAssign is replaced with ``ast.Pass``.
+
+    Upstream RestrictedPython collects errors and raises ``SyntaxError``
+    at the end of ``compile_restricted``, so returning the original
+    (unvisited) rejected node would be safe *today* — the bytecode is
+    never emitted.  But if the error-collection contract were ever
+    relaxed, leaving the original AugAssign in the tree would let a
+    rejected dunder write or non-dotted-name target compile to real
+    bytecode.
+
+    This test calls the transformer directly without going through
+    ``compile_restricted``, so the returned tree reflects what we would
+    emit if the compile-time error were suppressed.  Both error paths
+    in :meth:`visit_AugAssign` must produce ``ast.Pass``, never the
+    original node.
+    """
+    import ast  # noqa: PLC0415
+
+    # Dunder attribute target — rejected by the attribute-name guard.
+    tree = ast.parse("obj.__x += 1")
+    transformer = _AsyncRestrictingNodeTransformer()
+    transformer.visit(tree)
+    # The error must be recorded (compile would fail on this).
+    assert any("__x" in err for err in transformer.errors)
+    # The AugAssign must be replaced with Pass in the rewritten tree.
+    top = tree.body[0]
+    assert isinstance(top, ast.Pass), f"expected ast.Pass placeholder, got {type(top).__name__}"
+    assert top.lineno == 1
+
+    # Non-simple chain target — rejected by the dotted-name guard.
+    tree = ast.parse("f().x += 1")
+    transformer = _AsyncRestrictingNodeTransformer()
+    transformer.visit(tree)
+    assert any("plain dotted name" in err for err in transformer.errors)
+    top = tree.body[0]
+    assert isinstance(top, ast.Pass)
+
+
+def test_rejected_stmt_placeholder_copies_locations():
+    """The helper must copy source locations from the rejected node."""
+    import ast  # noqa: PLC0415
+
+    node = ast.parse("x += 1").body[0]
+    assert node.lineno == 1
+    placeholder = _rejected_stmt_placeholder(node)
+    assert isinstance(placeholder, ast.Pass)
+    assert placeholder.lineno == node.lineno
+    assert placeholder.col_offset == node.col_offset
 
 
 def test_augassign_rejects_nested_subscript_on_target(sandbox):

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -15,7 +15,7 @@ import asyncio
 
 import pytest
 
-from ida_mcp.sandbox import RestrictedPythonSandbox
+from ida_mcp.sandbox import _MAX_PRINT_CHARS, RestrictedPythonSandbox, _BoundedPrintCollector
 
 
 @pytest.fixture
@@ -570,6 +570,51 @@ return 0
         asyncio.run(sandbox.run(code))
 
 
+def test_augassign_rejects_subscript_on_target(sandbox):
+    """``obj[i].x += 1`` is rejected — the rewrite would evaluate ``obj[i]`` twice."""
+    code = """\
+class Box:
+    def __init__(self, n):
+        self.n = n
+boxes = [Box(0), Box(0)]
+boxes[0].n += 1
+return boxes[0].n
+"""
+    with pytest.raises(SyntaxError, match="evaluated twice"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_augassign_rejects_nested_subscript_on_target(sandbox):
+    """Subscripts nested deep in the target chain are also caught (ast.walk is recursive)."""
+    code = """\
+class Inner:
+    def __init__(self):
+        self.n = 0
+class Holder:
+    def __init__(self):
+        self.bag = [Inner()]
+h = Holder()
+h.bag[0].n += 1
+return 0
+"""
+    with pytest.raises(SyntaxError, match="evaluated twice"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_augassign_subscript_escape_hatch_via_temporary(sandbox):
+    """The documented workaround (assign to a temporary first) works here too."""
+    code = """\
+class Box:
+    def __init__(self, n):
+        self.n = n
+boxes = [Box(0), Box(0)]
+tmp = boxes[0]
+tmp.n += 5
+return boxes[0].n
+"""
+    assert asyncio.run(sandbox.run(code)) == 5
+
+
 # ---------------------------------------------------------------------------
 # Class-based escape attempts — defense-in-depth for the new class
 # definition / classmethod support.
@@ -706,6 +751,34 @@ return len(printed)
 """
     with pytest.raises(RuntimeError, match=r"print\(\) output exceeded"):
         asyncio.run(sandbox.run(code))
+
+
+def test_bounded_print_collector_tracks_cumulative_total():
+    """The cap is against cumulative writes; clearing ``txt`` does not reset it."""
+    collector = _BoundedPrintCollector()
+    first = "x" * (_MAX_PRINT_CHARS // 2)
+    collector.write(first)
+    assert collector._total_chars == len(first)
+
+    # Clearing the buffer must not reset the running total.
+    collector.txt.clear()
+
+    with pytest.raises(RuntimeError, match=r"print\(\) output exceeded"):
+        collector.write("y" * ((_MAX_PRINT_CHARS // 2) + 1))
+
+
+def test_bounded_print_collector_rejects_oversized_single_write():
+    """Rejected writes leave both ``_total_chars`` and ``txt`` untouched."""
+    collector = _BoundedPrintCollector()
+    collector.write("a" * 100)
+    before_total = collector._total_chars
+    before_txt = list(collector.txt)
+
+    with pytest.raises(RuntimeError, match=r"print\(\) output exceeded"):
+        collector.write("b" * (_MAX_PRINT_CHARS + 1))
+
+    assert collector._total_chars == before_total
+    assert collector.txt == before_txt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -15,7 +15,12 @@ import asyncio
 
 import pytest
 
-from ida_mcp.sandbox import _MAX_PRINT_CHARS, RestrictedPythonSandbox, _BoundedPrintCollector
+from ida_mcp.sandbox import (
+    _MAX_PRINT_CHARS,
+    RestrictedPythonSandbox,
+    _BoundedPrintCollector,
+    _is_forbidden_attr,
+)
 
 
 @pytest.fixture
@@ -523,7 +528,7 @@ return make().n
 """
     assert asyncio.run(sandbox.run(baseline)) == 0
 
-    with pytest.raises(SyntaxError, match="evaluated twice"):
+    with pytest.raises(SyntaxError, match="plain dotted name"):
         asyncio.run(
             sandbox.run(
                 """\
@@ -566,7 +571,7 @@ h = Holder()
 h.get().inner += 1
 return 0
 """
-    with pytest.raises(SyntaxError, match="evaluated twice"):
+    with pytest.raises(SyntaxError, match="plain dotted name"):
         asyncio.run(sandbox.run(code))
 
 
@@ -580,12 +585,13 @@ boxes = [Box(0), Box(0)]
 boxes[0].n += 1
 return boxes[0].n
 """
-    with pytest.raises(SyntaxError, match="evaluated twice"):
+    with pytest.raises(SyntaxError, match="plain dotted name"):
         asyncio.run(sandbox.run(code))
 
 
 def test_augassign_rejects_nested_subscript_on_target(sandbox):
-    """Subscripts nested deep in the target chain are also caught (ast.walk is recursive)."""
+    """Subscripts anywhere in the target chain are rejected — the
+    dotted-name check bottoms out at the first non-Attribute node."""
     code = """\
 class Inner:
     def __init__(self):
@@ -597,8 +603,79 @@ h = Holder()
 h.bag[0].n += 1
 return 0
 """
-    with pytest.raises(SyntaxError, match="evaluated twice"):
+    with pytest.raises(SyntaxError, match="plain dotted name"):
         asyncio.run(sandbox.run(code))
+
+
+def test_augassign_rejects_ifexp_on_target(sandbox):
+    """``(a if cond else b).x += 1`` — IfExp is not a dotted name, so the
+    sandbox refuses it even though neither side contains a Call/Subscript.
+
+    This is the gap the ``plain dotted name`` rule closes over the old
+    "Call/Subscript only" check: CPython evaluates the IfExp once, but
+    the sandbox rewrite would evaluate it twice and potentially take
+    different branches if ``cond`` depends on state the RHS mutates.
+    """
+    code = """\
+class Box:
+    def __init__(self, n):
+        self.n = n
+a = Box(0)
+b = Box(0)
+cond = True
+(a if cond else b).n += 1
+return 0
+"""
+    with pytest.raises(SyntaxError, match="plain dotted name"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_augassign_rejects_binop_on_target(sandbox):
+    """``(a + b).x += 1`` — arithmetic is not a dotted name.
+
+    A forced cast through ``BinOp`` cannot appear on the LHS of a
+    simple augmented assignment, but the rule still catches the
+    pathological form for completeness.
+    """
+    # ``BinOp`` as an attribute target is syntactically valid but
+    # semantically nonsense — still, the sandbox must not rewrite it.
+    code = """\
+class Box:
+    def __init__(self, n):
+        self.n = n
+    def __add__(self, other):
+        return Box(self.n + other.n)
+a = Box(1)
+b = Box(2)
+(a + b).n += 1
+return 0
+"""
+    with pytest.raises(SyntaxError, match="plain dotted name"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_augassign_accepts_deep_dotted_chain(sandbox):
+    """``a.b.c.d += 1`` — a deep chain of plain attribute lookups passes
+    the dotted-name check; the sandbox rewrites it correctly."""
+    code = """\
+class D:
+    def __init__(self):
+        self.v = 0
+class C:
+    def __init__(self):
+        self.d = D()
+class B:
+    def __init__(self):
+        self.c = C()
+class A:
+    def __init__(self):
+        self.b = B()
+a = A()
+a.b.c.d.v += 7
+a.b.c.d.v += 3
+return a.b.c.d.v
+"""
+    assert asyncio.run(sandbox.run(code)) == 10
 
 
 def test_augassign_subscript_escape_hatch_via_temporary(sandbox):
@@ -720,8 +797,67 @@ return s.format(object())
 def test_class_body_cannot_reference_metaclass_directly(sandbox):
     """``__metaclass__`` is injected into globals for ``class`` to work,
     but the user's own code must not be able to rebind or inspect it."""
-    with pytest.raises(SyntaxError, match="invalid"):
+    with pytest.raises(SyntaxError, match=r'"__metaclass__" is an invalid variable name'):
         asyncio.run(sandbox.run("return __metaclass__"))
+
+
+# ---------------------------------------------------------------------------
+# Upstream-API canaries — fail loudly when RestrictedPython internals move
+# ---------------------------------------------------------------------------
+
+
+def test_inspect_attributes_canary():
+    """Canary for RestrictedPython's ``INSPECT_ATTRIBUTES`` contract.
+
+    ``_is_forbidden_attr`` layers on top of
+    ``RestrictedPython.transformer.INSPECT_ATTRIBUTES`` to block
+    frame/code/generator/coroutine/traceback introspection names that
+    do not start with ``_`` (``f_globals``, ``co_code``, ``gi_code``,
+    ...).  If upstream renames or removes any of these, our blocklist
+    silently shrinks.  Pin a known subset so a RestrictedPython
+    version bump fails loudly and forces a manual re-audit of
+    :meth:`_AsyncRestrictingNodeTransformer.visit_Attribute` and
+    :func:`_sandbox_getattr`.
+    """
+    # Names confirmed present in RestrictedPython 8.1.  Keeping this
+    # list small and conservative — the goal is to detect a breaking
+    # rename / removal, not to enumerate every blocked name.
+    pinned = {
+        # Frame introspection.
+        "f_back",
+        "f_builtins",
+        "f_code",
+        "f_globals",
+        "f_locals",
+        "f_trace",
+        # Code object internals.
+        "co_code",
+        # Generator / coroutine introspection.
+        "gi_code",
+        "gi_frame",
+        "cr_code",
+        "cr_frame",
+        # Traceback walking.
+        "tb_frame",
+        "tb_next",
+    }
+    from RestrictedPython.transformer import INSPECT_ATTRIBUTES  # noqa: PLC0415
+
+    missing = pinned - set(INSPECT_ATTRIBUTES)
+    assert not missing, (
+        "RestrictedPython INSPECT_ATTRIBUTES lost pinned introspection "
+        f"names: {sorted(missing)}.  Re-audit sandbox.py._is_forbidden_attr "
+        "and _sandbox_getattr after the upgrade — names missing from "
+        "the upstream set will no longer be blocked at runtime."
+    )
+    # Every pinned name must also be rejected by our own helper, which
+    # composes the upstream set with the dunder rule.  If either side
+    # drifts, this catches it.
+    for name in pinned:
+        assert _is_forbidden_attr(name), (
+            f"_is_forbidden_attr({name!r}) returned False — the sandbox "
+            "attribute-name guard has regressed."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -508,6 +508,206 @@ def test_augassign_subscript_still_blocked(sandbox):
         asyncio.run(sandbox.run("d = {'a': 1}\nd['a'] += 1"))
 
 
+def test_augassign_rejects_call_on_target(sandbox):
+    """``f().x += 1`` is rejected at compile time because the rewrite
+    would evaluate ``f()`` twice and silently drop the store."""
+    # Baseline: plain reads of ``make().n`` work — the augassign form
+    # is what this test targets.
+    baseline = """\
+class Counter:
+    def __init__(self):
+        self.n = 0
+def make():
+    return Counter()
+return make().n
+"""
+    assert asyncio.run(sandbox.run(baseline)) == 0
+
+    with pytest.raises(SyntaxError, match="evaluated twice"):
+        asyncio.run(
+            sandbox.run(
+                """\
+class Counter:
+    def __init__(self):
+        self.n = 0
+def make():
+    return Counter()
+make().n += 1
+return 0
+"""
+            )
+        )
+
+
+def test_augassign_call_escape_hatch_via_temporary(sandbox):
+    """The recommended workaround from the error message must work."""
+    code = """\
+class Counter:
+    def __init__(self):
+        self.n = 0
+def make():
+    return Counter()
+tmp = make()
+tmp.n += 5
+return tmp.n
+"""
+    assert asyncio.run(sandbox.run(code)) == 5
+
+
+def test_augassign_rejects_method_call_on_target(sandbox):
+    """Method calls on the augassign target chain are also rejected."""
+    code = """\
+class Holder:
+    def __init__(self):
+        self.inner = object()
+    def get(self):
+        return self
+h = Holder()
+h.get().inner += 1
+return 0
+"""
+    with pytest.raises(SyntaxError, match="evaluated twice"):
+        asyncio.run(sandbox.run(code))
+
+
+# ---------------------------------------------------------------------------
+# Class-based escape attempts — defense-in-depth for the new class
+# definition / classmethod support.
+# ---------------------------------------------------------------------------
+
+
+def test_classmethod_cannot_walk_bases(sandbox):
+    """A classmethod cannot reach ``cls.__bases__`` at compile time."""
+    code = """\
+class C:
+    @classmethod
+    def attack(cls):
+        return cls.__bases__
+return C.attack()
+"""
+    with pytest.raises(SyntaxError, match="invalid attribute name"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_instance_cannot_read_dict(sandbox):
+    """``self.__dict__`` — dunder rule catches it at compile time."""
+    code = """\
+class C:
+    def __init__(self):
+        self.x = 1
+    def attack(self):
+        return self.__dict__
+return C().attack()
+"""
+    with pytest.raises(SyntaxError, match="invalid attribute name"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_classmethod_cannot_walk_class(sandbox):
+    """``cls.__class__`` — even via a classmethod, still blocked."""
+    code = """\
+class C:
+    @classmethod
+    def attack(cls):
+        return cls.__class__
+return C.attack()
+"""
+    with pytest.raises(SyntaxError, match="invalid attribute name"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_type_of_instance_blocks_bases(sandbox):
+    """``type(x).__bases__`` — ``type`` is a builtin but the dunder
+    attribute chain is still rejected at compile time."""
+    code = """\
+class C:
+    pass
+return type(C()).__bases__
+"""
+    with pytest.raises(SyntaxError, match="invalid attribute name"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_classmethod_cannot_runtime_escape_via_getattr(sandbox):
+    """Runtime ``getattr(cls, "__bases__")`` is rejected by the sandbox
+    guard even when the target is obtained inside a classmethod."""
+    code = """\
+class C:
+    @classmethod
+    def attack(cls):
+        return getattr(cls, '__bases__')
+return C.attack()
+"""
+    with pytest.raises(AttributeError, match="invalid attribute name"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_classmethod_cannot_runtime_escape_via_getattr_inspect(sandbox):
+    """``INSPECT_ATTRIBUTES`` names (``f_globals``, ``gi_code``, ...) are
+    blocked by the runtime ``getattr`` guard even when reached through a
+    classmethod — second line of defence behind the compile-time dunder
+    rule."""
+    code = """\
+class C:
+    @classmethod
+    def attack(cls):
+        return getattr(cls, 'f_globals')
+return C.attack()
+"""
+    with pytest.raises(AttributeError, match="invalid attribute name"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_str_format_blocked_on_subclass(sandbox):
+    """A user-defined ``str`` subclass cannot evade the ``format``
+    block by inheriting — the guard uses ``isinstance``/``issubclass``
+    against ``str``, so any string type is caught."""
+    code = """\
+class Safe(str):
+    pass
+s = Safe("{0}")
+return s.format(object())
+"""
+    with pytest.raises(NotImplementedError, match="format"):
+        asyncio.run(sandbox.run(code))
+
+
+def test_class_body_cannot_reference_metaclass_directly(sandbox):
+    """``__metaclass__`` is injected into globals for ``class`` to work,
+    but the user's own code must not be able to rebind or inspect it."""
+    with pytest.raises(SyntaxError, match="invalid"):
+        asyncio.run(sandbox.run("return __metaclass__"))
+
+
+# ---------------------------------------------------------------------------
+# Bounded PrintCollector — runaway print() loops must be killed before
+# they exhaust memory.
+# ---------------------------------------------------------------------------
+
+
+def test_print_cap_allows_reasonable_output(sandbox):
+    """Output under the cap is returned normally."""
+    code = """\
+for i in range(10):
+    print("line", i)
+return len(printed)
+"""
+    assert asyncio.run(sandbox.run(code)) > 0
+
+
+def test_print_cap_kills_runaway_loop(sandbox):
+    """An unbounded print loop hits the character cap and raises."""
+    # 4096 * 1024 ~= 4 MiB, well past the ~1 MiB cap.
+    code = """\
+chunk = "x" * 1024
+for i in range(4096):
+    print(chunk)
+return len(printed)
+"""
+    with pytest.raises(RuntimeError, match=r"print\(\) output exceeded"):
+        asyncio.run(sandbox.run(code))
+
+
 # ---------------------------------------------------------------------------
 # In-place operations
 # ---------------------------------------------------------------------------

--- a/tests/test_supervisor_pure.py
+++ b/tests/test_supervisor_pure.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from unittest.mock import AsyncMock, MagicMock
 
 import mcp.types as types
@@ -35,6 +36,7 @@ from ida_mcp.worker_provider import (
     Worker,
     WorkerPoolProvider,
     WorkerState,
+    _canonical_path,
     _enrich_result,
     _unwrap_auto_wrapped,
     expand_uri_template,
@@ -176,6 +178,66 @@ def test_expand_uri_template_no_params():
     """Template with no parameters returns unchanged."""
     result = expand_uri_template("ida://idb/metadata", {})
     assert result == "ida://idb/metadata"
+
+
+# ---------------------------------------------------------------------------
+# _canonical_path — dedup key construction
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_path_raw_binary(tmp_path):
+    """A raw binary path canonicalises to ``<realpath>.i64``."""
+    raw = tmp_path / "firmware.bin"
+    raw.write_bytes(b"\x00")
+    expected = os.path.realpath(str(raw)) + ".i64"
+    assert _canonical_path(str(raw)) == expected
+
+
+def test_canonical_path_idb_normalizes_extension(tmp_path):
+    """``.idb`` and ``.i64`` inputs both canonicalise to the ``.i64`` key."""
+    idb = tmp_path / "project.idb"
+    i64 = tmp_path / "project.i64"
+    assert _canonical_path(str(idb)) == _canonical_path(str(i64))
+
+
+def test_canonical_path_dedups_symlinks(tmp_path):
+    """Two symlinks pointing at the same binary share a dedup key."""
+    real = tmp_path / "real_binary"
+    real.write_bytes(b"\x00")
+    link_a = tmp_path / "link_a"
+    link_b = tmp_path / "link_b"
+    link_a.symlink_to(real)
+    link_b.symlink_to(real)
+
+    assert _canonical_path(str(link_a)) == _canonical_path(str(link_b))
+    assert _canonical_path(str(link_a)) == _canonical_path(str(real))
+
+
+def test_canonical_path_fat_arch_separates_slices(tmp_path):
+    """Different fat slices of the same binary get distinct keys so they
+    dedup to separate workers (and per-slice sidecar files on disk)."""
+    fat = tmp_path / "universal"
+    fat.write_bytes(b"\x00")
+    x86 = _canonical_path(str(fat), fat_arch="x86_64")
+    arm = _canonical_path(str(fat), fat_arch="arm64")
+    default = _canonical_path(str(fat))
+    assert x86 != arm
+    assert x86 != default
+    assert arm != default
+    assert x86.endswith(".x86_64.i64")
+    assert arm.endswith(".arm64.i64")
+
+
+def test_canonical_path_fat_arch_dedups_symlinked_slices(tmp_path):
+    """The slice suffix is appended after realpath resolution, so two
+    symlinks plus the same ``fat_arch`` still collapse to one key."""
+    real = tmp_path / "universal_real"
+    real.write_bytes(b"\x00")
+    link = tmp_path / "universal_link"
+    link.symlink_to(real)
+    assert _canonical_path(str(link), fat_arch="arm64") == _canonical_path(
+        str(real), fat_arch="arm64"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ wheels = [
 
 [[package]]
 name = "ida-mcp"
-version = "2.2.0.dev2"
+version = "2.2.0.dev3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["code-mode"] },


### PR DESCRIPTION
## Summary

- **Fat Mach-O binary support** — `open_database` now refuses a universal Mach-O without an explicit `fat_arch`, parses the fat header on disk (with a conservative Java `.class` defence), and stores each slice's sidecar at `<binary>.<arch>.i64` so architectures coexist on disk. The `WorkerPoolProvider` keys workers by slice, so multiple slices of the same file can be analyzed concurrently. Passing `fat_arch` on a thin / non-Mach-O file now raises `InvalidArgument` instead of being silently ignored.
- **Sandbox policy expansion** — the `execute` meta-tool's RestrictedPython sandbox now handles `class` statements, `async for` over async generators, `print(...)` (with a 1 MiB output cap), `*args`/`**kwargs` unpacking (incl. `asyncio.gather(*tasks)`), single-underscore "private" attributes, and `obj.x += y` augmented assignment. Augmented assignment to `f().x` / `obj.m().x` is rejected at compile time to avoid silent CPython divergence from double-evaluation. Dunder / frame-introspection / `str.format` escapes remain blocked at both compile and runtime — including on user-defined `str` subclasses and for attributes reached through classmethods.
- **Worker dedup keys** — `_canonical_path` now uses `os.path.realpath`, so two symlinks pointing at the same binary dedup to a single worker (behavior change for thin files too, not just fat slices).
- **Docs + version bump** — scan-friendly restructuring of `docs/architecture.md`, new `IDA_MCP_WORKER_LOG` env var documentation, corrected `IDA_MCP_MAX_WORKERS` phrasing, bump to `2.2.0.dev3`.

## Test plan

- [x] `uv run pytest` (covered by pre-commit hook on each commit)
- [x] `uv run ruff check src/` (covered by pre-commit)
- [ ] Open an x86_64/arm64 fat Mach-O without `fat_arch` → expect `AmbiguousFatBinary` with both slices listed
- [ ] Open the same fat binary twice with different `fat_arch` + `database_id` values → expect two distinct workers and sidecars at `<binary>.x86_64.i64` / `<binary>.arm64.i64`
- [ ] Pass `fat_arch="mips"` to a real fat binary → expect `UnknownFatArch`
- [ ] Pass `fat_arch="arm64"` to a thin ELF → expect `InvalidArgument`
- [ ] Open the same binary via two different symlinks → expect a single deduped worker
- [ ] `execute` a snippet defining a class with `@classmethod` / `@property` / `cls.count += 1`
- [ ] `execute` a snippet using `asyncio.gather(*[...])` and `async for`
- [ ] `execute` a snippet trying `obj.__class__` / `obj.__code__` / `str.format` → expect failures
- [ ] `execute` a snippet with `f().x += 1` → expect compile-time rejection
- [ ] `execute` a runaway `print` loop → expect `RuntimeError` from the 1 MiB cap