### PR TITLE
Fix open_database: drop leading dot from project subdir name

### DIFF
--- a/packages/re-mcp-ghidra/src/re_mcp_ghidra/session.py
+++ b/packages/re-mcp-ghidra/src/re_mcp_ghidra/session.py
@@ -21,7 +21,7 @@ from re_mcp_ghidra.exceptions import GhidraError
 
 log = logging.getLogger(__name__)
 
-_PROJECT_SUBDIR = ".ghidra_projects"
+_PROJECT_SUBDIR = "ghidra_projects"
 
 
 class Session:


### PR DESCRIPTION
Ran into this trying to open my first binary. `open_database` always fails because Ghidra rejects the dot-prefixed project dir name.

```
java.lang.IllegalArgumentException: Path element starting with '.' is not permitted
```

The check is in `GhidraProject.createProject`, which validates every path component. `.ghidra_projects` trips it.

Dropping the dot fixes it. After the change I opened `/bin/ls`, listed functions, decompiled `entry`, and closed cleanly with no errors.

Tested on Ghidra 12.1, Python 3.14, Linux.
