### PR TITLE
Add analyze_database tool and make wait_for_analysis run analysis on demand

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,11 +165,13 @@ All tools except management tools (`open_database`, `close_database`, `save_data
 
 `spawn_worker()` returns immediately. The worker subprocess, database open, and optional auto-analysis all run in a background `asyncio.Task` (`_background_spawn`). The initial response includes `"opening": true`, and callers must call `wait_for_analysis` to block until the database is ready for tool calls.
 
-When `run_auto_analysis=True`, `_background_spawn` chains into a second task (via `Worker.start_analysis()`) that dispatches `wait_for_analysis` through the normal proxy path once the open completes. While that task runs, `list_databases` reports `"analyzing": true` for the worker.
+When `run_auto_analysis=True`, `_background_spawn` chains into a second task (via `Worker.start_analysis()`) that dispatches the worker's `analyze_database` tool through the normal proxy path once the open completes. While that task runs, `list_databases` reports `"analyzing": true` for the worker.
 
-While background analysis is running, every worker tool except `wait_for_analysis` is rejected by `RoutingTool.run()` — the analysis engine is occupied. `wait_for_analysis` awaits the background task directly rather than making a redundant proxy call.
+Databases open with `run_auto_analysis=False` by default (only entry/export functions are defined). To keep `wait_for_analysis` honest, `wait_for_ready()` calls `_ensure_analysis_started()`, which triggers a **one-time** `analyze_database` pass when no analysis has run, is running, or has failed for the worker. The `Worker._analyzed` flag records completion so subsequent waits do not re-analyze; an explicit client call to the `analyze_database` tool sets the same flag via `RoutingTool.run()`.
 
-After analysis completes, worker metadata (function count, etc.) is refreshed via `get_database_info`, and MCP log and resource-list-changed notifications are sent if an `mcp_session` is available. Clients should call `wait_for_analysis` on the database to block until completion rather than polling `list_databases`. Background spawn and analysis tasks are cancelled during worker shutdown.
+While background analysis is running, every worker tool is rejected by `RoutingTool.run()` — the analysis engine is occupied. The supervisor-level `wait_for_analysis` awaits the background task directly rather than making a redundant proxy call.
+
+After analysis completes, worker metadata (function count, etc.) is refreshed via `get_database_info`, and MCP log and resource-list-changed notifications are sent if an `mcp_session` is available. Clients should call `wait_for_analysis` on the database to block until completion rather than polling `list_databases` (or call the `analyze_database` tool directly to (re)analyze an already-open database). Background spawn and analysis tasks are cancelled during worker shutdown.
 
 #### Fat Mach-O binaries (IDA backend)
 

--- a/packages/re-mcp-core/src/re_mcp/worker_provider.py
+++ b/packages/re-mcp-core/src/re_mcp/worker_provider.py
@@ -94,6 +94,11 @@ _WORKER_META_KEYS = (
     "capabilities",
 )
 
+# Name of the backend worker tool that runs auto-analysis to completion.
+# Each backend registers a client-visible ``analyze_database`` tool; the
+# supervisor also proxies it for background/on-demand analysis.
+ANALYZE_TOOL = "analyze_database"
+
 _RFC6570_QUERY_RE = re.compile(r"\{\?([^}]+)\}")
 
 
@@ -272,6 +277,7 @@ class Worker:
     _sessions: set[str] = field(default_factory=set)
     _analysis_task: asyncio.Task[None] | None = None
     _analysis_error: str | None = None
+    _analyzed: bool = False
     _ready_event: asyncio.Event = field(default_factory=asyncio.Event)
     _spawn_task: asyncio.Task[None] | None = None
     _spawn_error: str | None = None
@@ -338,6 +344,15 @@ class Worker:
     def analysis_error(self) -> str | None:
         """Error message from the last background analysis, or ``None``."""
         return self._analysis_error
+
+    @property
+    def analyzed(self) -> bool:
+        """True once auto-analysis has completed for this worker."""
+        return self._analyzed
+
+    def mark_analyzed(self) -> None:
+        """Record that auto-analysis has completed for this worker."""
+        self._analyzed = True
 
     @property
     def opening(self) -> bool:
@@ -446,9 +461,10 @@ class RoutingTool(Tool):
         database = arguments.pop("database", None)
         worker = self._provider.resolve_worker(database)
 
-        # During background analysis, block all tools except
-        # wait_for_analysis — the worker thread is occupied by analysis.
-        if worker.analyzing and self.name != "wait_for_analysis":
+        # During background analysis the worker thread is occupied, so block
+        # all worker tools.  Clients await completion via the supervisor-level
+        # wait_for_analysis (a management tool, not routed through here).
+        if worker.analyzing:
             raise ToolError(
                 f"Database '{worker.database_id}' is being analyzed in the background. "
                 "Tools are blocked during analysis — call "
@@ -467,6 +483,11 @@ class RoutingTool(Tool):
 
         if enriched.isError:
             raise ToolError(_extract_error_text(enriched))
+
+        # An explicit analyze_database call fully analyzes the database; record
+        # it so a subsequent wait_for_analysis does not redundantly re-run.
+        if self.name == ANALYZE_TOOL:
+            worker.mark_analyzed()
 
         return ToolResult(
             content=enriched.content,
@@ -1142,6 +1163,23 @@ class WorkerPoolProvider(Provider):
             )
         return worker
 
+    def _ensure_analysis_started(self, worker: Worker) -> None:
+        """Kick off a one-time analysis pass if none has run for this worker.
+
+        No-op when analysis has already completed, is in flight, previously
+        failed, or the worker is not in an active state.  Safe to call without
+        ``_lock``: the check-and-start is synchronous (no ``await`` between the
+        guard and :meth:`Worker.start_analysis`), so concurrent callers on the
+        single event loop cannot both start a task.
+        """
+        if (
+            not worker.analyzed
+            and not worker.analyzing
+            and worker.analysis_error is None
+            and worker.state not in _INACTIVE_STATES
+        ):
+            worker.start_analysis(self._background_analysis(worker))
+
     async def wait_for_ready(self, database: str | None) -> dict[str, Any]:
         """Wait for a database to finish opening and/or analysis.
 
@@ -1162,6 +1200,12 @@ class WorkerPoolProvider(Provider):
                 f"Database '{worker.database_id}' failed to open: {worker.spawn_error}",
                 error_type="SpawnFailed",
             )
+
+        # Databases open with run_auto_analysis=False by default, which defines
+        # only entry points.  wait_for_analysis is documented as the call that
+        # makes a database ready, so trigger a one-time analysis pass here when
+        # none has run — otherwise this would return an unanalyzed database.
+        self._ensure_analysis_started(worker)
 
         # If analysis is running, await the background task directly
         # rather than making a redundant proxy call that would race with it.
@@ -1231,6 +1275,7 @@ class WorkerPoolProvider(Provider):
                 await w.wait_ready()
             if w.spawn_error:
                 return
+            self._ensure_analysis_started(w)
             task = w._analysis_task
             if task is not None and not task.done():
                 await asyncio.shield(task)
@@ -1580,7 +1625,7 @@ class WorkerPoolProvider(Provider):
     ) -> None:
         """Run auto-analysis on a worker in the background.
 
-        Dispatches ``wait_for_analysis`` through the normal proxy path,
+        Dispatches ``analyze_database`` through the normal proxy path,
         then refreshes worker metadata.
         """
         db_id = worker.database_id
@@ -1590,7 +1635,7 @@ class WorkerPoolProvider(Provider):
 
             result = await self.proxy_to_worker(
                 worker,
-                "wait_for_analysis",
+                ANALYZE_TOOL,
                 {},
             )
 
@@ -1602,6 +1647,8 @@ class WorkerPoolProvider(Provider):
                     mcp_session, "warning", f"Auto-analysis failed for {db_id}: {err_text}"
                 )
                 return
+
+            worker.mark_analyzed()
 
             # Refresh metadata (function_count etc. change after analysis).
             info_result = await self.proxy_to_worker(worker, "get_database_info", {})

--- a/packages/re-mcp-ghidra/src/re_mcp_ghidra/tools/analysis.py
+++ b/packages/re-mcp-ghidra/src/re_mcp_ghidra/tools/analysis.py
@@ -102,12 +102,14 @@ def register(mcp: FastMCP) -> None:
 
     @mcp.tool(annotations=ANNO_MUTATE, tags={"analysis"})
     @session.require_open
-    def wait_for_analysis() -> AnalysisCompleteResult:
-        """Run Ghidra's auto-analysis and wait for it to complete.
+    def analyze_database() -> AnalysisCompleteResult:
+        """Run Ghidra's auto-analysis to completion on the open program.
 
-        Call this after opening a database or making changes (patches, type
-        applications) to ensure the program is fully analyzed before querying.
-        Returns a summary of database statistics after analysis finishes.
+        Use this to fully analyze a database that was opened without analysis
+        (``open_database`` defaults to ``run_auto_analysis=False``), or after
+        making changes (patches, type applications) to ensure the program is
+        fully analyzed before querying.  Returns a summary of database
+        statistics after analysis finishes.
         """
         from ghidra.base.project import GhidraProject  # noqa: PLC0415
 

--- a/packages/re-mcp-ghidra/src/re_mcp_ghidra/transforms.py
+++ b/packages/re-mcp-ghidra/src/re_mcp_ghidra/transforms.py
@@ -10,6 +10,8 @@ PINNED_TOOLS = frozenset(
     {
         *MANAGEMENT_TOOLS,
         *META_TOOLS,
+        # Analysis
+        "analyze_database",
         # Exploration
         "get_database_info",
         "list_functions",

--- a/packages/re-mcp-ida/src/re_mcp_ida/server.py
+++ b/packages/re-mcp-ida/src/re_mcp_ida/server.py
@@ -16,7 +16,7 @@ also registers signal handlers, which Python restricts to the main thread).
 The MCP server's asyncio event loop runs on a **daemon background thread**.
 All sync tool functions are dispatched to the main thread via
 :func:`~re_mcp_ida.helpers.call_ida` (backed by a :class:`MainThreadExecutor`).
-Async tools (like ``wait_for_analysis``) run on the event-loop thread and
+Async tools (like ``analyze_database``) run on the event-loop thread and
 dispatch individual IDA calls to the main thread as needed.
 
 This separation ensures that IDA's auto-analysis engine gets dedicated

--- a/packages/re-mcp-ida/src/re_mcp_ida/tools/analysis.py
+++ b/packages/re-mcp-ida/src/re_mcp_ida/tools/analysis.py
@@ -200,13 +200,16 @@ def register(mcp: FastMCP):
         tags={"analysis"},
     )
     @session.require_open
-    async def wait_for_analysis() -> AnalysisCompleteResult:
-        """Wait for IDA's auto-analysis to complete.
+    async def analyze_database() -> AnalysisCompleteResult:
+        """Run IDA's auto-analysis to completion on the open database.
 
-        Call this after making changes (patches, type applications) to ensure
-        the database is fully analyzed before querying.  Returns a summary of
-        database statistics after analysis finishes so you can sanity-check
-        results without extra round trips.
+        Use this to fully analyze a database that was opened without analysis
+        (``open_database`` defaults to ``run_auto_analysis=False``, which defines
+        only entry/export functions), or after making changes (patches, type
+        applications) to ensure the database is fully analyzed before querying.
+        Enables the auto-analyzer, processes all queued work, and returns a
+        summary of database statistics so you can sanity-check results without
+        extra round trips.
         """
         start_time = time.monotonic()
 

--- a/packages/re-mcp-ida/src/re_mcp_ida/transforms.py
+++ b/packages/re-mcp-ida/src/re_mcp_ida/transforms.py
@@ -10,6 +10,8 @@ PINNED_TOOLS = frozenset(
     {
         *MANAGEMENT_TOOLS,
         *META_TOOLS,
+        # Analysis
+        "analyze_database",
         # Exploration
         "get_database_info",
         "list_functions",

--- a/tests/test_supervisor_pure.py
+++ b/tests/test_supervisor_pure.py
@@ -1293,14 +1293,61 @@ class TestWaitForReady:
     """Test WorkerPoolProvider.wait_for_ready."""
 
     @pytest.mark.asyncio
-    async def test_ready_worker_returns_immediately(self):
+    async def test_ready_analyzed_worker_returns_immediately(self):
         pool = _setup_pool([])
         worker = _add_worker(pool, "db1", {})
         worker._ready_event.set()
+        worker.mark_analyzed()
+        pool.proxy_to_worker = AsyncMock()
 
         result = await pool.wait_for_ready("db1")
         assert result["status"] == "ready"
         assert result["database"] == "db1"
+        # Already analyzed → no analysis pass triggered.
+        pool.proxy_to_worker.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unanalyzed_worker_triggers_analysis(self):
+        """A ready-but-unanalyzed worker gets a one-time analysis pass."""
+        pool = _setup_pool([])
+        worker = _add_worker(pool, "db1", {})
+        worker._ready_event.set()
+
+        wait_result = _ok_result({"status": "analysis_complete"})
+        info_result = _ok_result({"function_count": 42})
+        pool.proxy_to_worker = AsyncMock(side_effect=[wait_result, info_result])
+
+        result = await pool.wait_for_ready("db1")
+
+        assert result["status"] == "ready"
+        assert worker.analyzed is True
+        # First proxied call runs the analyze_database tool.
+        assert pool.proxy_to_worker.call_args_list[0][0][1] == "analyze_database"
+
+    @pytest.mark.asyncio
+    async def test_analyzed_worker_not_reanalyzed(self):
+        """wait_for_ready does not re-run analysis once a worker is analyzed."""
+        pool = _setup_pool([])
+        worker = _add_worker(pool, "db1", {})
+        worker._ready_event.set()
+        worker.mark_analyzed()
+        pool.proxy_to_worker = AsyncMock()
+
+        await pool.wait_for_ready("db1")
+        pool.proxy_to_worker.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prior_analysis_error_not_retried(self):
+        """A worker whose analysis already failed is not silently retried."""
+        pool = _setup_pool([])
+        worker = _add_worker(pool, "db1", {})
+        worker._ready_event.set()
+        worker.record_analysis_error("boom")
+        pool.proxy_to_worker = AsyncMock()
+
+        with pytest.raises(BackendError, match="Analysis failed"):
+            await pool.wait_for_ready("db1")
+        pool.proxy_to_worker.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_spawn_failure_raises(self):
@@ -1318,6 +1365,7 @@ class TestWaitForReady:
         pool = _setup_pool([])
         worker = _add_worker(pool, "db1", {})
         worker.state = WorkerState.STARTING
+        worker.mark_analyzed()
 
         async def _set_ready():
             await asyncio.sleep(0.01)


### PR DESCRIPTION
## Problem

Databases open with `run_auto_analysis=False` by default, which defines only entry/export functions. There was no client-reachable way to complete auto-analysis on an already-open database short of closing and reopening it.

The root cause is a name collision. The worker tool that actually runs full auto-analysis (`enable_auto(True); auto_wait()` for IDA, `GhidraProject.analyze()` for Ghidra) was named `wait_for_analysis` — the same name as the supervisor management tool — so the bootstrap filter (`worker_provider.py`) excluded it from the client tool list. The client-visible management `wait_for_analysis` only awaited a background analysis task, which exists solely when `run_auto_analysis=True` at open time. On a database opened with analysis off, it therefore returned immediately **without analyzing anything**, contradicting its name.

## Changes

- **Rename** the worker-side `wait_for_analysis` → **`analyze_database`** (IDA and Ghidra). It no longer collides, so it becomes a client-visible `ANNO_MUTATE` tool. Pinned in both backends' `PINNED_TOOLS` for discoverability.
- **Make `wait_for_analysis` honest:** `wait_for_ready()` now triggers a one-time `analyze_database` pass via `_ensure_analysis_started()` when no analysis has run, is running, or has failed for the worker. A new `Worker._analyzed` flag prevents redundant re-analysis; an explicit `analyze_database` call sets it too (via `RoutingTool.run()`).
- `_background_analysis` proxies `analyze_database` and marks the worker analyzed on success. Dropped the now-dead `wait_for_analysis` exception in the analysis-block guard.
- Updated `docs/architecture.md` and added/adjusted supervisor tests.

## Trade-off

Since the server instructions tell clients to always call `wait_for_analysis` after `open_database`, every database (including already-analyzed `.i64`/`.gpr` files) now gets one idempotent analysis pass on first wait. For IDA this is effectively instant when nothing is queued; for Ghidra `GhidraProject.analyze()` on a fully-analyzed program is cheap but non-zero.

## Testing

- New/updated supervisor tests pass (on-demand trigger fires, already-analyzed skips, prior error not retried).
- `ruff check` / `ruff format` clean; idalib threading lint passes.
- Pre-existing platform-specific test failures (POSIX signals, symlinks, fat Mach-O, darwin/linux paths) are unrelated to this change (confirmed identical on the base tree in a Windows dev environment).