### PR TITLE
expose the hex-rays bits that previously needed run_script

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -75,6 +75,7 @@ Function prototypes and calling conventions.
 | `get_function_type` | Get function signature, return type, calling convention, and parameters. |
 | `set_function_type` | Set a function's prototype from a C declaration string. |
 | `set_function_calling_convention` | Change calling convention (cdecl, stdcall, fastcall, thiscall, pascal). |
+| `set_call_type` | Force the callee prototype at one call site, for indirect calls with no symbol (IDA). |
 
 ## Function Flags
 
@@ -107,6 +108,8 @@ Stack frame and local variable analysis.
 |------|-------------|
 | `get_stack_frame` | Get the stack frame layout: members with offsets, sizes, and names. |
 | `get_function_vars` | Get local variables via decompilation: names, types, widths, arg/result flags. |
+| `set_stack_delta` | Override the SP delta at an address — the fix for "positive sp value" (IDA). |
+| `delete_stack_delta` | Remove an SP delta override (IDA). |
 
 ## Cross-References
 
@@ -254,7 +257,11 @@ Decompiler interaction — variable management, microcode, and comments.
 |------|-------------|
 | `rename_decompiler_variable` | Rename a local variable in pseudocode. |
 | `retype_decompiler_variable` | Change the type of a local variable in pseudocode. |
-| `list_decompiler_variables` | List all variables in a function's pseudocode. |
+| `list_decompiler_variables` | List all variables in a function's pseudocode, with Hex-Rays attributes (BYREF, OVERLAPPED, MAPDST, ...). |
+| `map_decompiler_variable` | Merge one local into another so both locations read as one variable (IDA). |
+| `clear_decompiler_variable_maps` | Drop every variable merge in a function (IDA). |
+| `get_pseudocode_line_map` | Map `decompile_function` line numbers to addresses (IDA). |
+| `refresh_decompilation` | Drop a function's cached decompilation so the next decompile is fresh (IDA). |
 | `get_microcode` | Get microcode at a given maturity level (IDA). |
 | `set_decompiler_comment` | Set a comment in pseudocode at a specific address. |
 | `get_decompiler_comments` | Get all user comments in a function's pseudocode. |
@@ -265,9 +272,9 @@ Decompiler AST (ctree) exploration and pattern matching.
 
 | Tool | Description |
 |------|-------------|
-| `get_ctree` | Get the decompiler AST for a function. `depth` is 1-10 (default 3). |
+| `get_ctree` | Get the decompiler AST for a function. `depth` is 1-10 (default 3). Nodes carry `exflags` (FPOP, UNDEF, VFTABLE, ...) and calls carry `call_flags` (NORET, HELPER, FINAL). |
 | `find_ctree_calls` | Find function calls in the AST, optionally filtered by callee name. |
-| `find_ctree_patterns` | Find patterns in the AST: calls, string_refs, comparisons, assignments, casts, pointer_derefs, or all (IDA). |
+| `find_ctree_patterns` | Find patterns in the AST: calls, string_refs, comparisons, assignments, casts, pointer_derefs, or all (IDA). Comparisons and assignments include their operands; string_refs cover globals holding literals, not just `cot_str`. |
 
 ## Types
 

--- a/packages/re-mcp-ida/src/re_mcp_ida/helpers.py
+++ b/packages/re-mcp-ida/src/re_mcp_ida/helpers.py
@@ -49,6 +49,7 @@ from re_mcp.helpers import (
 )
 
 from re_mcp_ida.exceptions import IDAError
+from re_mcp_ida.models import DecompilerWarning
 
 log = logging.getLogger(__name__)
 
@@ -74,6 +75,7 @@ __all__ = [
     "call_ida",
     "check_cancelled",
     "clean_disasm_line",
+    "collect_warnings",
     "compile_filter",
     "decode_insn_at",
     "decode_string",
@@ -298,6 +300,26 @@ def decompile_at(
     if cfunc is None:
         raise IDAError("Decompilation returned no result", error_type="DecompilationFailed")
     return cfunc, func
+
+
+# WARN_MAX is the sentinel, not a real warning id
+_WARN_NAMES: dict[int, str] = {
+    getattr(ida_hexrays, attr): attr
+    for attr in dir(ida_hexrays)
+    if attr.startswith("WARN_") and attr != "WARN_MAX"
+}
+
+
+def collect_warnings(cfunc: ida_hexrays.cfunc_t) -> list[DecompilerWarning]:
+    """Structured form of the ``//`` warning comments Hex-Rays prints in the pseudocode."""
+    return [
+        DecompilerWarning(
+            address=format_address(w.ea),
+            id=_WARN_NAMES.get(w.id, f"WARN_{w.id}"),
+            text=w.text,
+        )
+        for w in cfunc.get_warnings()
+    ]
 
 
 @ida_dispatch

--- a/packages/re-mcp-ida/src/re_mcp_ida/models.py
+++ b/packages/re-mcp-ida/src/re_mcp_ida/models.py
@@ -13,9 +13,26 @@ re-exported here for convenient single-source imports.
 
 from __future__ import annotations
 
-from re_mcp.models import (  # noqa: F401  — re-export
+from pydantic import BaseModel, Field
+from re_mcp.models import (
     FunctionChunk,
     FunctionSummary,
     PaginatedResult,
     RenameResult,
 )
+
+__all__ = [
+    "DecompilerWarning",
+    "FunctionChunk",
+    "FunctionSummary",
+    "PaginatedResult",
+    "RenameResult",
+]
+
+
+class DecompilerWarning(BaseModel):
+    """A non-fatal Hex-Rays warning raised while decompiling."""
+
+    address: str = Field(description="Address the warning refers to (hex).")
+    id: str = Field(description="Warning id name (e.g. WARN_BAD_SP).")
+    text: str = Field(description="Formatted warning text.")

--- a/packages/re-mcp-ida/src/re_mcp_ida/tools/ctree.py
+++ b/packages/re-mcp-ida/src/re_mcp_ida/tools/ctree.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 from typing import Annotated
 
+import ida_bytes
 import ida_hexrays
+import ida_nalt
 import ida_name
 from fastmcp import FastMCP
 from pydantic import BaseModel, Field
@@ -19,6 +21,7 @@ from re_mcp_ida.helpers import (
     META_DECOMPILER,
     Address,
     IDAError,
+    decode_string,
     decompile_at,
     format_address,
     get_func_name,
@@ -167,6 +170,10 @@ def register(mcp: FastMCP):
                 if _type and not _type.empty():
                     result["type"] = str(_type)
 
+                exflags = _decode_flags(expr.exflags, _EXFL_NAMES)
+                if exflags:
+                    result["exflags"] = exflags
+
                 # Number literal
                 if item.op == ida_hexrays.cot_num:
                     result["value"] = expr.numval()
@@ -189,6 +196,10 @@ def register(mcp: FastMCP):
                         call_target = _item_to_dict(expr.x, current_depth - 1)
                         if call_target:
                             result["call_target"] = call_target
+                    if expr.a:
+                        call_flags = _decode_flags(expr.a.flags, _CFL_NAMES)
+                        if call_flags:
+                            result["call_flags"] = call_flags
                     if expr.a and current_depth > 1:
                         args = []
                         for i in range(len(expr.a)):
@@ -377,14 +388,43 @@ def register(mcp: FastMCP):
                         name = ida_name.get_name(target.obj_ea) or ""
                     results["calls"].append({"callee": name, "address": addr})
 
-                if (pattern_type in ("all", "string_refs")) and expr.op == ida_hexrays.cot_str:
-                    results["string_refs"].append({"string": expr.string, "address": addr})
+                if pattern_type in ("all", "string_refs"):
+                    if expr.op == ida_hexrays.cot_str:
+                        results["string_refs"].append({"string": expr.string, "address": addr})
+                    elif expr.op == ida_hexrays.cot_obj and expr.is_cstr():
+                        # Globals holding a string literal read as string refs too, and
+                        # they are far more common than cot_str — a whole binary can have
+                        # zero of the latter
+                        text = _obj_string(expr.obj_ea)
+                        if text is not None:
+                            results["string_refs"].append(
+                                {
+                                    "string": text,
+                                    "address": addr,
+                                    "obj_ea": format_address(expr.obj_ea),
+                                }
+                            )
 
                 if (pattern_type in ("all", "comparisons")) and expr.op in _COMPARISON_OPS:
-                    results["comparisons"].append({"op": _op_name(expr.op), "address": addr})
+                    results["comparisons"].append(
+                        {
+                            "op": _op_name(expr.op),
+                            "address": addr,
+                            "is_fpop": expr.is_fpop(),
+                            "x": _operand_summary(expr.x, cfunc),
+                            "y": _operand_summary(expr.y, cfunc),
+                        }
+                    )
 
                 if (pattern_type in ("all", "assignments")) and expr.op in _ASSIGNMENT_OPS:
-                    results["assignments"].append({"op": _op_name(expr.op), "address": addr})
+                    results["assignments"].append(
+                        {
+                            "op": _op_name(expr.op),
+                            "address": addr,
+                            "x": _operand_summary(expr.x, cfunc),
+                            "y": _operand_summary(expr.y, cfunc),
+                        }
+                    )
 
                 if (pattern_type in ("all", "casts")) and expr.op == ida_hexrays.cot_cast:
                     target_type = (
@@ -428,3 +468,58 @@ _OP_NAMES: dict[int, str] = {
 
 def _op_name(op: int) -> str:
     return _OP_NAMES.get(op, f"op_{op}")
+
+
+def _flag_table(prefix: str, skip: frozenset[str]) -> dict[int, str]:
+    """Build a ``bit -> short name`` table from ``ida_hexrays`` constants."""
+    return {
+        getattr(ida_hexrays, attr): attr[len(prefix) :]
+        for attr in dir(ida_hexrays)
+        if attr.startswith(prefix) and attr not in skip
+    }
+
+
+# EXFL_ALL is a mask over every other bit, not a bit of its own
+_EXFL_NAMES = _flag_table("EXFL_", frozenset({"EXFL_ALL"}))
+_CFL_NAMES = _flag_table("CFL_", frozenset())
+
+
+def _decode_flags(value: int, table: dict[int, str]) -> list[str]:
+    return [name for bit, name in table.items() if value & bit]
+
+
+def _obj_string(ea: int) -> str | None:
+    """Read the string literal at *ea*, or ``None`` if it can't be decoded."""
+    if is_bad_addr(ea):
+        return None
+    strtype = ida_nalt.get_str_type(ea)
+    if strtype is None:
+        return None
+    return decode_string(ea, ida_bytes.get_max_strlit_length(ea, strtype), strtype)
+
+
+def _operand_summary(expr, cfunc) -> dict | None:
+    """One-level description of an operand, so callers need no second get_ctree fetch."""
+    if expr is None:
+        return None
+
+    out: dict = {"op": _op_name(expr.op)}
+    if expr.type and not expr.type.empty():
+        out["type"] = str(expr.type)
+
+    match expr.op:
+        case ida_hexrays.cot_num:
+            out["value"] = expr.numval()
+        case ida_hexrays.cot_str:
+            out["string"] = expr.string
+        case ida_hexrays.cot_obj:
+            out["obj_ea"] = format_address(expr.obj_ea)
+            out["name"] = ida_name.get_name(expr.obj_ea) or ""
+        case ida_hexrays.cot_var:
+            idx = expr.v.idx if expr.v else -1
+            if 0 <= idx < len(cfunc.lvars):
+                out["var_name"] = cfunc.lvars[idx].name
+        case _:
+            pass
+
+    return out

--- a/packages/re-mcp-ida/src/re_mcp_ida/tools/decompiler.py
+++ b/packages/re-mcp-ida/src/re_mcp_ida/tools/decompiler.py
@@ -12,6 +12,7 @@ from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
 from re_mcp_ida.helpers import (
+    ANNO_DESTRUCTIVE,
     ANNO_MUTATE,
     ANNO_READ_ONLY,
     META_DECOMPILER,
@@ -20,6 +21,7 @@ from re_mcp_ida.helpers import (
     decompile_at,
     format_address,
     get_func_name,
+    is_bad_addr,
     parse_type,
     resolve_address,
     resolve_function,
@@ -102,6 +104,10 @@ class DecompilerVariable(BaseModel):
     is_reg_var: bool = Field(description="Whether this is a register variable.")
     register_name: str | None = Field(default=None, description="Register name (if reg var).")
     stack_offset: int | None = Field(default=None, description="Stack offset (if stack var).")
+    flags: list[str] = Field(
+        default_factory=list,
+        description="Hex-Rays attributes (BYREF, OVERLAPPED, MAPDST, SPLIT, ...).",
+    )
 
 
 class ListDecompilerVarsResult(BaseModel):
@@ -111,6 +117,45 @@ class ListDecompilerVarsResult(BaseModel):
     name: str = Field(description="Function name.")
     variable_count: int = Field(description="Number of variables.")
     variables: list[DecompilerVariable] = Field(description="Variable list.")
+
+
+class PseudocodeLine(BaseModel):
+    """A pseudocode line and the address it came from."""
+
+    line: int = Field(description="Line number (0-based, matches decompile_function output).")
+    address: str = Field(description="Lowest address contributing to this line (hex).")
+
+
+class PseudocodeLineMapResult(BaseModel):
+    """Line-to-address mapping for a function's pseudocode."""
+
+    function: str = Field(description="Function address (hex).")
+    name: str = Field(description="Function name.")
+    line_count: int = Field(description="Total number of pseudocode lines.")
+    lines: list[PseudocodeLine] = Field(description="Lines that map to an address.")
+
+
+class RefreshDecompilationResult(BaseModel):
+    """Result of invalidating a cached decompilation."""
+
+    function: str = Field(description="Function address (hex).")
+    name: str = Field(description="Function name.")
+    was_cached: bool = Field(description="Whether a cached decompilation was discarded.")
+
+
+class MapDecompilerVarResult(BaseModel):
+    """Result of mapping one decompiler variable onto another."""
+
+    function: str = Field(description="Function address (hex).")
+    source: str = Field(description="Source variable name.")
+    target: str = Field(description="Target variable name.")
+
+
+class ClearVarMapsResult(BaseModel):
+    """Result of clearing a function's variable mappings."""
+
+    function: str = Field(description="Function address (hex).")
+    cleared: int = Field(description="Number of mappings removed.")
 
 
 _MATURITY_MAP = {
@@ -123,6 +168,44 @@ _MATURITY_MAP = {
     "MMAT_GLBOPT3": ida_hexrays.MMAT_GLBOPT3,
     "MMAT_LVARS": ida_hexrays.MMAT_LVARS,
 }
+
+# There are no CVAR_* constants in the Python bindings, only these predicates.
+# Names match the keywords Hex-Rays prints in the pseudocode where one exists.
+_LVAR_FLAG_PREDICATES: tuple[tuple[str, str], ...] = (
+    ("BYREF", "is_used_byref"),
+    ("OVERLAPPED", "is_overlapped_var"),
+    ("MAPDST", "is_mapdst_var"),
+    ("SPLIT", "is_split_var"),
+    ("THISARG", "is_thisarg"),
+    ("INASM", "in_asm"),
+    ("FAKE", "is_fake_var"),
+    ("AUTOMAP", "is_automapped"),
+    ("DUMMY", "is_dummy_arg"),
+    ("NOTARG", "is_notarg"),
+    ("UNUSED", "is_decl_unused"),
+)
+
+
+def _lvar_flags(lvar) -> list[str]:
+    # SWIG exposes some of these as methods and some as plain bool properties
+    flags = []
+    for name, pred in _LVAR_FLAG_PREDICATES:
+        attr = getattr(lvar, pred)
+        if attr() if callable(attr) else attr:
+            flags.append(name)
+    return flags
+
+
+def _find_lvar(cfunc, name: str):
+    """Look up an lvar by name, raising the usual NotFound with the valid choices."""
+    for lvar in cfunc.lvars:
+        if lvar.name == name:
+            return lvar
+    raise IDAError(
+        f"Variable not found: {name!r}",
+        error_type="NotFound",
+        available_variables=[lvar.name for lvar in cfunc.lvars],
+    )
 
 
 def register(mcp: FastMCP):
@@ -389,9 +472,11 @@ def register(mcp: FastMCP):
     ) -> ListDecompilerVarsResult:
         """List Hex-Rays locals/params for ONE function (for stack layout use get_stack_frame).
 
-        Returns each variable's name, type, storage (stack/register), and whether it is
-        a parameter. Use this before rename_decompiler_variable or
-        retype_decompiler_variable to get the exact current names.
+        Returns each variable's name, type, storage (stack/register), whether it is
+        a parameter, and its Hex-Rays attributes (BYREF, OVERLAPPED, MAPDST, ...) so
+        they need not be parsed out of the pseudocode text. Use this before
+        rename_decompiler_variable or retype_decompiler_variable to get the exact
+        current names.
 
         Args:
             function_address: Address or name of the function.
@@ -410,6 +495,7 @@ def register(mcp: FastMCP):
                 if lvar.is_reg_var()
                 else None,
                 stack_offset=lvar.get_stkoff() if lvar.is_stk_var() else None,
+                flags=_lvar_flags(lvar),
             )
             variables.append(var)
 
@@ -419,3 +505,152 @@ def register(mcp: FastMCP):
             variable_count=len(variables),
             variables=variables,
         )
+
+    @mcp.tool(
+        annotations=ANNO_READ_ONLY,
+        tags={"decompiler"},
+        meta=META_DECOMPILER,
+    )
+    @session.require_open
+    def get_pseudocode_line_map(
+        function_address: Address,
+    ) -> PseudocodeLineMapResult:
+        """Map decompile_function's pseudocode line numbers to addresses.
+
+        Line numbers are 0-based and line up with splitting decompile_function's
+        pseudocode on newlines. Only lines carrying at least one addressable ctree
+        item appear; the address reported is the lowest one on that line. Use it to
+        hand a pseudocode line off to an address-taking tool.
+
+        Args:
+            function_address: Address or name of the function.
+        """
+        cfunc, func = decompile_at(function_address)
+
+        # treeitems is only populated once the pseudocode has been printed
+        sv = cfunc.get_pseudocode()
+
+        lowest: dict[int, int] = {}
+        for item in cfunc.treeitems:
+            ea = item.ea
+            if is_bad_addr(ea):
+                continue
+            coords = cfunc.find_item_coords(item)
+            # returns (None, None) for items that never made it into the listing
+            if not coords or coords[1] is None or coords[1] < 0:
+                continue
+            line = coords[1]
+            if line not in lowest or ea < lowest[line]:
+                lowest[line] = ea
+
+        return PseudocodeLineMapResult(
+            function=format_address(func.start_ea),
+            name=get_func_name(func.start_ea),
+            line_count=sv.size(),
+            lines=[
+                PseudocodeLine(line=line, address=format_address(ea))
+                for line, ea in sorted(lowest.items())
+            ],
+        )
+
+    @mcp.tool(
+        annotations=ANNO_MUTATE,
+        tags={"decompiler"},
+        meta=META_DECOMPILER,
+    )
+    @session.require_open
+    def refresh_decompilation(
+        function_address: Address,
+    ) -> RefreshDecompilationResult:
+        """Drop the cached decompilation of a function so the next decompile is fresh.
+
+        Needed after changing something the pseudocode depends on but that Hex-Rays
+        does not notice on its own — a callee's prototype, a struct layout, a stack
+        delta, a forced call type. Without it decompile_function keeps returning the
+        stale text.
+
+        Args:
+            function_address: Address or name of the function.
+        """
+        func = resolve_function(function_address)
+        was_cached = ida_hexrays.mark_cfunc_dirty(func.start_ea, False)
+        return RefreshDecompilationResult(
+            function=format_address(func.start_ea),
+            name=get_func_name(func.start_ea),
+            was_cached=was_cached,
+        )
+
+    @mcp.tool(
+        annotations=ANNO_MUTATE,
+        tags={"decompiler", "modification"},
+        meta=META_DECOMPILER,
+    )
+    @session.require_open
+    def map_decompiler_variable(
+        function_address: Address,
+        source_name: str,
+        target_name: str,
+    ) -> MapDecompilerVarResult:
+        """Merge one Hex-Rays local into another, so both locations read as one variable.
+
+        The documented fix for a variable the decompiler split into pieces (a 64-bit
+        value living as two 32-bit halves, say): map the fragment onto the variable
+        you want to keep. The target then carries the MAPDST attribute. If Hex-Rays
+        rejects the pairing the next decompilation warns with WARN_BAD_MAPDST.
+
+        The source loses its own identity once mapped, so there is no way to name it
+        again afterwards — undo with clear_decompiler_variable_maps.
+
+        Args:
+            function_address: Address or name of the function.
+            source_name: Variable to merge away.
+            target_name: Variable to merge it into.
+        """
+        cfunc, func = decompile_at(function_address)
+
+        source = _find_lvar(cfunc, source_name)
+        target = _find_lvar(cfunc, target_name)
+        if source_name == target_name:
+            raise IDAError("Cannot map a variable onto itself", error_type="InvalidArgument")
+
+        lvinf = ida_hexrays.lvar_uservec_t()
+        ida_hexrays.restore_user_lvar_settings(lvinf, func.start_ea)
+        ida_hexrays.lvar_mapping_insert(lvinf.lmaps, source, target)
+        ida_hexrays.save_user_lvar_settings(func.start_ea, lvinf)
+        ida_hexrays.mark_cfunc_dirty(func.start_ea, False)
+
+        return MapDecompilerVarResult(
+            function=format_address(func.start_ea),
+            source=source_name,
+            target=target_name,
+        )
+
+    @mcp.tool(
+        annotations=ANNO_DESTRUCTIVE,
+        tags={"decompiler", "modification"},
+        meta=META_DECOMPILER,
+    )
+    @session.require_open
+    def clear_decompiler_variable_maps(
+        function_address: Address,
+    ) -> ClearVarMapsResult:
+        """Drop every map_decompiler_variable merge in a function, splitting the vars back apart.
+
+        This is the undo for map_decompiler_variable. It is all-or-nothing: a merged
+        variable stops existing under its old name, so individual merges cannot be
+        addressed afterwards.
+
+        Args:
+            function_address: Address or name of the function.
+        """
+        func = resolve_function(function_address)
+
+        lvinf = ida_hexrays.lvar_uservec_t()
+        ida_hexrays.restore_user_lvar_settings(lvinf, func.start_ea)
+        cleared = ida_hexrays.lvar_mapping_size(lvinf.lmaps)
+        if cleared:
+            ida_hexrays.lvar_mapping_clear(lvinf.lmaps)
+            ida_hexrays.save_user_lvar_settings(func.start_ea, lvinf)
+            ida_hexrays.mark_cfunc_dirty(func.start_ea, False)
+
+        return ClearVarMapsResult(function=format_address(func.start_ea), cleared=cleared)

--- a/packages/re-mcp-ida/src/re_mcp_ida/tools/export.py
+++ b/packages/re-mcp-ida/src/re_mcp_ida/tools/export.py
@@ -165,6 +165,8 @@ def _decompile_one(func_ea: int, name: str) -> tuple[ExportedPseudocode | None, 
 
     sv = cfunc.get_pseudocode()
     lines = [ida_lines.tag_remove(sv[j].line) for j in range(sv.size())]
+    # No warnings here on purpose: guessed-type warnings repeat across every caller
+    # and were ~36% of a 10-function export. decompile_function carries them instead.
     return ExportedPseudocode(
         name=name, address=format_address(func_ea), pseudocode="\n".join(lines)
     ), None

--- a/packages/re-mcp-ida/src/re_mcp_ida/tools/frames.py
+++ b/packages/re-mcp-ida/src/re_mcp_ida/tools/frames.py
@@ -6,18 +6,23 @@
 
 from __future__ import annotations
 
+import ida_frame
 import ida_typeinf
 import idc
 from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
 from re_mcp_ida.helpers import (
+    ANNO_DESTRUCTIVE,
+    ANNO_MUTATE,
     ANNO_READ_ONLY,
     META_DECOMPILER,
     Address,
+    IDAError,
     decompile_at,
     format_address,
     get_func_name,
+    resolve_address,
     resolve_function,
 )
 from re_mcp_ida.session import session
@@ -71,6 +76,16 @@ class GetFunctionVarsResult(BaseModel):
     name: str = Field(description="Function name.")
     variable_count: int = Field(description="Number of variables.")
     variables: list[FunctionVariable] = Field(description="Variable list.")
+
+
+class StackDeltaResult(BaseModel):
+    """Result of a stack delta override."""
+
+    function: str = Field(description="Function address (hex).")
+    address: str = Field(description="Address the override applies to (hex).")
+    old_delta: int = Field(description="Previous SP delta at this address.")
+    delta: int | None = Field(default=None, description="New SP delta (null when deleted).")
+    sp_value: int = Field(description="SP value at this address after the change.")
 
 
 def register(mcp: FastMCP):
@@ -160,4 +175,69 @@ def register(mcp: FastMCP):
             name=get_func_name(func.start_ea),
             variable_count=len(variables),
             variables=variables,
+        )
+
+    @mcp.tool(
+        annotations=ANNO_MUTATE,
+        tags={"functions", "modification"},
+    )
+    @session.require_open
+    def set_stack_delta(
+        address: Address,
+        delta: int,
+    ) -> StackDeltaResult:
+        """Override the stack pointer delta at an address (the fix for "positive sp value").
+
+        IDA tracks how each instruction moves SP; when it gets that wrong the function
+        gets a broken frame and Hex-Rays refuses or produces nonsense. Pin the correct
+        delta here, then call refresh_decompilation on the function.
+
+        Args:
+            address: Address whose SP delta is wrong.
+            delta: Correct SP delta at that address (bytes, usually negative for a push).
+        """
+        func = resolve_function(address)
+        ea = resolve_address(address)
+
+        old_delta = ida_frame.get_sp_delta(func, ea)
+        if not ida_frame.add_user_stkpnt(ea, delta):
+            raise IDAError(
+                f"add_user_stkpnt failed at {format_address(ea)}", error_type="OperationFailed"
+            )
+
+        return StackDeltaResult(
+            function=format_address(func.start_ea),
+            address=format_address(ea),
+            old_delta=old_delta,
+            delta=delta,
+            sp_value=ida_frame.get_spd(func, ea),
+        )
+
+    @mcp.tool(
+        annotations=ANNO_DESTRUCTIVE,
+        tags={"functions", "modification"},
+    )
+    @session.require_open
+    def delete_stack_delta(
+        address: Address,
+    ) -> StackDeltaResult:
+        """Remove a stack delta override, letting IDA's own SP tracking take over again.
+
+        Args:
+            address: Address whose override should be dropped.
+        """
+        func = resolve_function(address)
+        ea = resolve_address(address)
+
+        old_delta = ida_frame.get_sp_delta(func, ea)
+        if not ida_frame.del_stkpnt(func, ea):
+            raise IDAError(
+                f"No stack delta override at {format_address(ea)}", error_type="NotFound"
+            )
+
+        return StackDeltaResult(
+            function=format_address(func.start_ea),
+            address=format_address(ea),
+            old_delta=old_delta,
+            sp_value=ida_frame.get_spd(func, ea),
         )

--- a/packages/re-mcp-ida/src/re_mcp_ida/tools/function_type.py
+++ b/packages/re-mcp-ida/src/re_mcp_ida/tools/function_type.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import ida_idp
 import ida_nalt
 import ida_typeinf
 import idc
@@ -17,8 +18,11 @@ from re_mcp_ida.helpers import (
     ANNO_READ_ONLY,
     Address,
     IDAError,
+    decode_insn_at,
     format_address,
     get_func_name,
+    parse_type,
+    resolve_address,
     resolve_function,
 )
 from re_mcp_ida.session import session
@@ -66,6 +70,14 @@ class SetCallingConventionResult(BaseModel):
     name: str = Field(description="Function name.")
     old_convention: str = Field(description="Previous calling convention.")
     convention: str = Field(description="New calling convention.")
+
+
+class SetCallTypeResult(BaseModel):
+    """Result of forcing a call site's callee type."""
+
+    address: str = Field(description="Call site address (hex).")
+    function: str = Field(description="Containing function address (hex).")
+    type: str = Field(description="Applied callee prototype.")
 
 
 _CC_NAMES = {
@@ -222,4 +234,43 @@ def register(mcp: FastMCP):
             name=get_func_name(func.start_ea),
             old_convention=old_convention,
             convention=convention,
+        )
+
+    @mcp.tool(
+        annotations=ANNO_MUTATE,
+        tags={"functions", "types"},
+    )
+    @session.require_open
+    def set_call_type(
+        address: Address,
+        type_string: str,
+    ) -> SetCallTypeResult:
+        """Force the callee prototype at ONE call site (for indirect calls with no symbol).
+
+        set_function_type retypes a function everywhere; this pins the type used at a
+        single call instruction, which is the only handle you get on `(*v3)(a1, a2)`
+        style dispatch. Follow with refresh_decompilation on the containing function.
+
+        Args:
+            address: Address of the call instruction.
+            type_string: C function declaration, e.g. "int __fastcall f(void *this, int a)".
+        """
+        ea = resolve_address(address)
+        func = resolve_function(ea)
+
+        if not ida_idp.is_call_insn(decode_insn_at(ea)):
+            raise IDAError(
+                f"{format_address(ea)} is not a call instruction", error_type="InvalidArgument"
+            )
+
+        tinfo = parse_type(type_string)
+        if not ida_typeinf.apply_callee_tinfo(ea, tinfo):
+            raise IDAError(
+                f"Failed to apply callee type at {format_address(ea)}", error_type="ApplyFailed"
+            )
+
+        return SetCallTypeResult(
+            address=format_address(ea),
+            function=format_address(func.start_ea),
+            type=str(tinfo),
         )

--- a/packages/re-mcp-ida/src/re_mcp_ida/tools/functions.py
+++ b/packages/re-mcp-ida/src/re_mcp_ida/tools/functions.py
@@ -29,6 +29,7 @@ from re_mcp_ida.helpers import (
     async_paginate_iter,
     call_ida,
     clean_disasm_line,
+    collect_warnings,
     compile_filter,
     decompile_at,
     format_address,
@@ -37,7 +38,13 @@ from re_mcp_ida.helpers import (
     resolve_address,
     resolve_function,
 )
-from re_mcp_ida.models import FunctionChunk, FunctionSummary, PaginatedResult, RenameResult
+from re_mcp_ida.models import (
+    DecompilerWarning,
+    FunctionChunk,
+    FunctionSummary,
+    PaginatedResult,
+    RenameResult,
+)
 from re_mcp_ida.session import session
 
 # ---------------------------------------------------------------------------
@@ -102,6 +109,9 @@ class DecompilationResult(BaseModel):
     address: str = Field(description="Function start address (hex).")
     name: str = Field(description="Function name.")
     pseudocode: str = Field(description="Decompiled C pseudocode.")
+    warnings: list[DecompilerWarning] | None = Field(
+        default=None, description="Non-fatal Hex-Rays warnings, if any."
+    )
 
 
 class DisassemblyInstruction(BaseModel):
@@ -345,10 +355,12 @@ def register(mcp: FastMCP):
         cfunc, func = decompile_at(target)
         sv = cfunc.get_pseudocode()
         lines = [ida_lines.tag_remove(sv[i].line) for i in range(sv.size())]
+        warnings = collect_warnings(cfunc)
         return DecompilationResult(
             address=format_address(func.start_ea),
             name=get_func_name(func.start_ea),
             pseudocode="\n".join(lines),
+            warnings=warnings or None,
         )
 
     @mcp.tool(
@@ -368,6 +380,10 @@ def register(mcp: FastMCP):
 
         Requires a Hex-Rays decompiler license. For quick inspection without
         decompilation, use disassemble_function (faster, no license needed).
+
+        Non-fatal Hex-Rays warnings come back structured in `warnings` (id, address,
+        text) rather than only as `//` comments in the text. To map pseudocode lines
+        back to addresses, use get_pseudocode_line_map.
 
         Args:
             address: Address of the function (hex string or symbol).


### PR DESCRIPTION
a bunch of the IDA backend was only reachable by dropping into `run_script`. this closes most of it.

existing tools got more out of them:

- `get_ctree` nodes carry `exflags`, calls carry `call_flags`. omitted when zero
- `find_ctree_patterns` comparisons/assignments now carry their `x`/`y` operands and `is_fpop`, so no second `get_ctree` fetch
- `find_ctree_patterns(string_refs)` also matches `cot_obj` globals holding literals. the binary i tested on has zero `cot_str` and 10 `cot_obj` string refs, so the old behaviour just returned fuck all
- `list_decompiler_variables` returns `flags` (`BYREF`, `OVERLAPPED`, `MAPDST`, ...) so you don't have to regex the pseudocode
- `decompile_function` returns structured `warnings` (`id`, `address`, `text`), not just inline `//` comments

new tools:

- `get_pseudocode_line_map` (line number to address)
- `refresh_decompilation` (`mark_cfunc_dirty`, for stale output after a callee retype or struct edit)
- `set_stack_delta` / `delete_stack_delta` (the documented fix for `positive sp value`)
- `map_decompiler_variable` / `clear_decompiler_variable_maps`
- `set_call_type` (per call site callee prototype, for indirect calls)

notes:

- warnings are deliberately not on `export_all_pseudocode`. guessed-type warnings repeat across every caller and came out to 36% of a 10 function export, and that tool is for grep sweeps
- no `unmap_decompiler_variable`. a mapped lvar loses its name so there's nothing left to key on, hence the clear-all
- lvar flags come from the `lvar_t` predicates, not a `CVAR_*` bitmask. there are no `CVAR_*` constants in the 9.3 python bindings, so a `dir()` based table silently comes back empty, which is annoying as shit to debug
- IDA only, this is all hex-rays specific. lvar split is out too, it needs an interactive `vdui_t`

tested on IDA 9.3 against an x86-64 PE, driving the built server over stdio. ruff and the idalib threading lint are clean, pytest unchanged.